### PR TITLE
__memset fix

### DIFF
--- a/common/include/string.h
+++ b/common/include/string.h
@@ -15,7 +15,7 @@ void* memset(void *ptr, int value, size_t num);
 // Version of memset with better arguments for MOS. All non-pointer arguments
 // can fit in registers, and there is no superfluous return value. Compiler
 // intrinsic memset calls use this version, and user code is free to as well.
-void __memset(char *ptr, char value, size_t num);
+void __memset(char *ptr, char value, size_t num) __attribute__((used));
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
After recent changes compilation of program using `printf` fails with:

```
ld.lld: error: undefined symbol: __memset
>>> referenced by ld-temp.o
>>>               lto.tmp:(_ntoa_long)
>>> referenced by ld-temp.o
>>>               lto.tmp:(_ntoa_long)
clang-13: error: ld.lld command failed with exit code 1 (use -v to see invocation)
```

It seems __memset symbol gets stripped from libc.a for some reason. I've found this solution here: https://www.keil.com/support/man/docs/armcc/armcc_chr1359124978363.htm - it solves it for me.