### PR TITLE
set atari stack location to MEMTOP

### DIFF
--- a/atari/800xl/ldscripts/link.ld
+++ b/atari/800xl/ldscripts/link.ld
@@ -29,6 +29,3 @@ ASSERT(__rc127 == 0x00ff, "Inconsistent zero page map.")
 
 ASSERT(ADDR(.header) == 0x2000, "header at incorrect address.")
 ASSERT(_start == 0x2000, "_start began at different address than expected.")
-
-/* Set initial soft stack address (It grows down.) */
-__stack = 0x1FFF;

--- a/atari/800xl/lib/crt0.s
+++ b/atari/800xl/lib/crt0.s
@@ -1,14 +1,13 @@
 .section .start,"ax",@progbits
 .global _start
 _start:
-    ; Initialize soft stack pointer.
-    LDA #mos16lo(__stack)
+    ; Initialize soft stack pointer to MEMTOP
+
+    LDA $2e5
     STA mos8(__rc0)
-    LDA #mos16hi(__stack)
+    LDA $2e6
     STA mos8(__rc1)
 
     ; FIXME: Zero BSS.
-    JSR main
 
-    ; It's no longer safe to reenter BASIC.
-    end: JMP end
+    JMP main


### PR DESCRIPTION
dynamically set atari stack location to MEMTOP value (0xBBFF with BASIC disabled, 0x9BFF with BASIC enabled, just below video memory)
Also remove infinite loop on the end (and return to DOS)