### PR TITLE
A800 chrout bugfix

### DIFF
--- a/atari/800xl/lib/chrout.c
+++ b/atari/800xl/lib/chrout.c
@@ -1,4 +1,4 @@
-void __chrout(char c) {
+__attribute__((noinline)) void __chrout(char c) {
   if(c == '\n') c = 0x9b;
   __attribute__((leaf)) asm volatile(
     "tax\n"


### PR DESCRIPTION
Current version of atari __chrout  doesn't work when inlined.