### PR TITLE
Make std::set/get_new_handler work per standard.

### DIFF
--- a/mos-platform/common/include/new
+++ b/mos-platform/common/include/new
@@ -17,13 +17,31 @@ new_handler set_new_handler(new_handler new_p) noexcept;
 
 } // namespace std
 
+/**
+The standard forms of the new are implicitly declared by the compiler, 
+and are automatically declared in every translation unit.  
+These are provided here for exposition.  The user may provide their
+own definitions of these functions to override their behavior.
+
 void *operator new(std::size_t size);
 void *operator new[](std::size_t size);
+
+Likewise, for the the default implementation of delete:
+void operator delete(void *ptr) noexcept;
+void operator delete[](void *ptr) noexcept
+*/
+
+// All default implementations of all allocating overloads of operator new forward 
+// to this overload.
+// This is slightly against the standard, which states that the nothrow overloads
+// forward to the throwing overloads. We do not implement it this
+// way because such an implementation would require the nothrow overloads to
+// catch bad_alloc thrown by the throwing overload.  
 void *operator new(std::size_t count, const std::nothrow_t &tag) noexcept;
+
 void *operator new[](std::size_t count, const std::nothrow_t &tag) noexcept;
+
 void *operator new(std::size_t count, void *ptr);
 void *operator new[](std::size_t count, void *ptr);
-void operator delete(void *ptr) noexcept;
-void operator delete[](void *ptr) noexcept;
 
 #endif //__NEW_H__

--- a/mos-platform/common/lib/new.cc
+++ b/mos-platform/common/lib/new.cc
@@ -259,7 +259,7 @@ public:
 
 private:
   // Nodes are added at the end of the list.
-  auto add_node(block_node *node) {
+  block_node * add_node(block_node *node) {
     list_node *node_last = m_head;
     for (; node_last->m_next; node_last = node_last->m_next) {
     }
@@ -293,18 +293,6 @@ blocklist &get_free_list() {
   return free_list;
 }
 
-void run_new_handler() {
-  const auto newp = std::get_new_handler();
-  if (newp) {
-    newp();
-  } else {
-    // Standard c++ requires throwing bad_alloc here.
-    // TODO: implement throw.
-    // Calling terminate here behaves similarly to a caller that
-    // does not catch bad_alloc, and therefore has an unhandled exception.
-    std::terminate();
-  }
-}
 } // namespace
 
 // Heap limit is set to SIZE_MAX at initialization to indicate that
@@ -335,11 +323,6 @@ __attribute__((weak)) void free(void *ptr) {
 
 }
 
-// All operator new implementations forward to this overload.
-// This is slightly against the standard, which states that the nothrow overloads
-// forward to the throwing overloads. We do not implement it this
-// way because such an implementation would require the nothrow overloads to
-// catch bad_alloc thrown by the throwing overload.  
 __attribute__((weak)) void *operator new(std::size_t count,
                                          const std::nothrow_t &) noexcept {
   // The allocating new functions must allow any user-installed


### PR DESCRIPTION
Doing so revealed some issues  in __set_heap_limit:
1. New memory needs to be coalesced into the previous blocks, so a large allocation spanning new and old heap limits can succeed.
2. The __heap_bytes_free accounting was not correct after extending the heap limit.