### PR TITLE
Type Traits Implementation

### DIFF
--- a/mos-platform/common/include/CMakeLists.txt
+++ b/mos-platform/common/include/CMakeLists.txt
@@ -19,6 +19,7 @@ llvm_mos_sdk_install(FILES
   stdlib.h
   string.h
   type_traits
+  __type_traits_impl.h
   typeinfo
   zero_bss.S
   )

--- a/mos-platform/common/include/__type_traits_impl.h
+++ b/mos-platform/common/include/__type_traits_impl.h
@@ -1,0 +1,41 @@
+#ifndef __TYPE_TRAITS_BASE_H__
+#define __TYPE_TRAITS_BASE_H__
+
+// This implementation header factors out common type traits
+// needed in multiple headers.
+// Some portions of type_traits depend on cstddef, and 
+// Some portions of cstddef depend on type_traits.
+
+namespace std
+{
+
+template <class T, T v> struct integral_constant {
+  static constexpr T value = v;
+  using value_type = T;
+  using type = integral_constant;
+  constexpr operator value_type() const noexcept { return value; }
+  constexpr value_type operator()() const noexcept { return value; }
+};
+
+template <class T>
+struct is_integral : public integral_constant<bool, __is_integral(T)> {};
+
+template <class T> inline constexpr bool is_integral_v = is_integral<T>::value;
+
+template <bool B, class T = void> struct enable_if {};
+
+template <class T> struct enable_if<true, T> { typedef T type; };
+
+template <bool B, class T = void>
+using enable_if_t = typename enable_if<B, T>::type;
+
+// Suppress deprecation notice for volatile-qualified return type resulting
+// from volatile-qualified types _Tp.
+template <class _Tp> _Tp &&__declval(int);
+template <class _Tp> _Tp __declval(long);
+
+template <class _Tp> decltype(__declval<_Tp>(0)) declval() noexcept;
+
+} // namespace std
+
+#endif //__TYPE_TRAITS_BASE_H__

--- a/mos-platform/common/include/__type_traits_impl.h
+++ b/mos-platform/common/include/__type_traits_impl.h
@@ -1,13 +1,12 @@
-#ifndef __TYPE_TRAITS_BASE_H__
-#define __TYPE_TRAITS_BASE_H__
+#ifndef __TYPE_TRAITS_IMPL_H__
+#define __TYPE_TRAITS_IMPL_H__
 
 // This implementation header factors out common type traits
 // needed in multiple headers.
-// Some portions of type_traits depend on cstddef, and 
+// Some portions of type_traits depend on cstddef, and
 // Some portions of cstddef depend on type_traits.
 
-namespace std
-{
+namespace std {
 
 template <class T, T v> struct integral_constant {
   static constexpr T value = v;
@@ -38,4 +37,4 @@ template <class _Tp> decltype(__declval<_Tp>(0)) declval() noexcept;
 
 } // namespace std
 
-#endif //__TYPE_TRAITS_BASE_H__
+#endif //__TYPE_TRAITS_IMPL_H__

--- a/mos-platform/common/include/cstddef
+++ b/mos-platform/common/include/cstddef
@@ -1,7 +1,7 @@
 #ifndef _CSTDDEF_
 #define _CSTDDEF_
 #include <stddef.h>
-#include <type_traits>
+#include <__type_traits_impl.h>
 
 namespace std {
 using size_t = ::size_t;

--- a/mos-platform/common/include/type_traits
+++ b/mos-platform/common/include/type_traits
@@ -1,47 +1,29 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
 #ifndef _TYPE_TRAITS_
 #define _TYPE_TRAITS_
 
-namespace std {
+#include <cstddef>
+#include <__type_traits_impl.h>
 
-template <class T, T v> struct integral_constant {
-  static constexpr T value = v;
-  using value_type = T;
-  using type = integral_constant;
-  constexpr operator value_type() const noexcept { return value; }
-  constexpr value_type operator()() const noexcept { return value; }
-};
+namespace std {
 
 template <bool B> using bool_constant = integral_constant<bool, B>;
 
 typedef integral_constant<bool, true> true_type;
 typedef integral_constant<bool, false> false_type;
 
-template <class T> struct is_integral : false_type {};
+template <bool B, class T, class F> struct conditional { typedef T type; };
+template <class T, class F> struct conditional<false, T, F> { typedef F type; };
 
-template <> struct is_integral<bool> : true_type {};
-
-template <> struct is_integral<char> : true_type {};
-
-template <> struct is_integral<unsigned char> : true_type {};
-
-template <> struct is_integral<short> : true_type {};
-
-template <> struct is_integral<unsigned short> : true_type {};
-
-template <> struct is_integral<int> : true_type {};
-
-template <> struct is_integral<unsigned int> : true_type {};
-
-template <> struct is_integral<long> : true_type {};
-
-template <> struct is_integral<unsigned long> : true_type {};
-
-template <bool B, class T = void> struct enable_if {};
-
-template <class T> struct enable_if<true, T> { typedef T type; };
-
-template <bool B, class T = void>
-using enable_if_t = typename enable_if<B, T>::type;
+template <bool B, class T, class F>
+using conditional_t = typename conditional<B, T, F>::type;
 
 template <class T> struct remove_cv { typedef T type; };
 template <class T> struct remove_cv<const T> { typedef T type; };
@@ -49,13 +31,1176 @@ template <class T> struct remove_cv<volatile T> { typedef T type; };
 template <class T> struct remove_cv<const volatile T> { typedef T type; };
 template <class T> using remove_cv_t = typename remove_cv<T>::type;
 
-template <class T> struct make_unsigned;
+template <class T> struct add_cv { typedef const volatile T type; };
+template <class T> using add_cv_t = typename add_cv<T>::type;
+template <class T> struct add_const { typedef const T type; };
+template <class T> using add_const_t = typename add_const<T>::type;
+template <class T> struct add_volatile { typedef volatile T type; };
+template <class T> using add_volatile_t = typename add_volatile<T>::type;
 
-template <> struct make_unsigned<char> { typedef unsigned char type; };
-template <> struct make_unsigned<int> { typedef unsigned int type; };
-template <> struct make_unsigned<long> { typedef unsigned long type; };
+template <class T> struct remove_reference { typedef T type; };
+template <class T> struct remove_reference<T &> { typedef T type; };
+template <class T> struct remove_reference<T &&> { typedef T type; };
 
-template <class T> using make_unsigned_t = typename make_unsigned<T>::type;
+template <class T>
+using remove_reference_t = typename remove_reference<T>::type;
+
+template <class T> struct type_identity { using type = T; };
+
+template <class T> // Note that `cv void&` is a substitution failure
+auto __try_add_lvalue_reference(int) -> type_identity<T &>;
+template <class T> // Handle T = cv void case
+auto __try_add_lvalue_reference(...) -> type_identity<T>;
+
+template <class T> auto __try_add_rvalue_reference(int) -> type_identity<T &&>;
+template <class T> auto __try_add_rvalue_reference(...) -> type_identity<T>;
+
+template <class T>
+struct add_lvalue_reference : decltype(__try_add_lvalue_reference<T>(0)) {};
+
+template <class T>
+using add_lvalue_reference_t = typename add_lvalue_reference<T>::type;
+
+template <class T>
+struct add_rvalue_reference : decltype(__try_add_rvalue_reference<T>(0)) {
+};
+
+template <class T>
+using add_rvalue_reference_t = typename add_rvalue_reference<T>::type;
+
+namespace __detail {
+
+template <class T>
+auto try_add_pointer(int)
+    -> type_identity<remove_reference_t<T> *>;
+template <class T> auto try_add_pointer(...) -> type_identity<T>;
+
+} // namespace __detail
+
+template <class T>
+struct add_pointer : decltype(__detail::try_add_pointer<T>(0)) {};
+
+template <class T> using add_pointer_t = typename add_pointer<T>::type;
+
+template <class T> struct remove_extent { typedef T type; };
+
+template <class T> struct remove_extent<T[]> { typedef T type; };
+
+template <class T, size_t N> struct remove_extent<T[N]> {
+  typedef T type;
+};
+
+template <class T> using remove_extent_t = typename remove_extent<T>::type;
+
+template <class T> struct remove_all_extents { typedef T type; };
+
+template <class T> struct remove_all_extents<T[]> {
+  typedef typename remove_all_extents<T>::type type;
+};
+
+template <class T, std::size_t N> struct remove_all_extents<T[N]> {
+  typedef typename remove_all_extents<T>::type type;
+};
+
+template <class T>
+using remove_all_extents_t = typename remove_all_extents<T>::type;
+
+template <class T> struct remove_pointer { typedef T type; };
+template <class T> struct remove_pointer<T *> { typedef T type; };
+template <class T> struct remove_pointer<T *const> { typedef T type; };
+template <class T> struct remove_pointer<T *volatile> { typedef T type; };
+template <class T> struct remove_pointer<T *const volatile> { typedef T type; };
+template <class T> using remove_pointer_t = typename remove_pointer<T>::type;
+
+// make_signed / make_unsigned
+struct __nat {
+  __nat() = delete;
+  __nat(const __nat &) = delete;
+  __nat &operator=(const __nat &) = delete;
+  ~__nat() = delete;
+};
+
+
+template <class T, class U>
+struct is_same : public bool_constant<__is_same(T, U)> {};
+
+template <class T, class U>
+inline constexpr bool is_same_v = is_same<T, U>::value;
+
+template <class T> struct is_void : public bool_constant<__is_void(T)> {};
+
+template <class T> inline constexpr bool is_void_v = is_void<T>::value;
+
+template <class T>
+struct is_null_pointer : is_same<nullptr_t, remove_cv_t<T>> {};
+
+template <class T>
+inline constexpr bool is_null_pointer_v = is_null_pointer<T>::value;
+
+template <class T> struct is_array : public bool_constant<__is_array(T)> {};
+
+template <class T> inline constexpr bool is_array_v = is_array<T>::value;
+
+template <class T> struct is_enum : public bool_constant<__is_enum(T)> {};
+
+template <class T> inline constexpr bool is_enum_v = is_enum<T>::value;
+
+template <class T>
+struct is_floating_point : public bool_constant<__is_floating_point(T)> {};
+
+template <class T>
+inline constexpr bool is_floating_pointr_v = is_floating_point<T>::value;
+
+template <class T> struct is_union : public bool_constant<__is_union(T)> {};
+
+template <class T> inline constexpr bool is_union_v = is_union<T>::value;
+
+template <class T> struct is_class : public bool_constant<__is_class(T)> {};
+
+template <class T> inline constexpr bool is_class_v = is_class<T>::value;
+
+template <class T>
+struct is_function : public bool_constant<__is_function(T)> {};
+
+template <class T> inline constexpr bool is_function_v = is_function<T>::value;
+
+template <class T> struct is_pointer : public bool_constant<__is_pointer(T)> {};
+
+template <class T> inline constexpr bool is_pointer_v = is_pointer<T>::value;
+
+template <class T>
+struct is_lvalue_reference : public bool_constant<__is_lvalue_reference(T)> {};
+
+template <class T>
+inline constexpr bool is_lvalue_reference_v = is_lvalue_reference<T>::value;
+
+template <class T>
+struct is_rvalue_reference : public bool_constant<__is_rvalue_reference(T)> {};
+
+template <class T>
+inline constexpr bool is_rvalue_reference_v = is_rvalue_reference<T>::value;
+
+template <class T>
+struct is_member_object_pointer
+    : public bool_constant<__is_member_object_pointer(T)> {};
+
+template <class T>
+inline constexpr bool is_member_object_pointer_v =
+    is_member_object_pointer<T>::value;
+
+template <class T>
+struct is_member_function_pointer
+    : public bool_constant<__is_member_function_pointer(T)> {};
+
+template <class T>
+inline constexpr bool is_member_function_pointer_v =
+    is_member_function_pointer<T>::value;
+
+template <class T>
+struct is_fundamental : public bool_constant<__is_fundamental(T)> {};
+
+template <class T>
+inline constexpr bool is_fundamental_v = is_fundamental<T>::value;
+
+template <class T>
+struct is_arithmetic : public bool_constant<__is_arithmetic(T)> {};
+
+template <class T>
+inline constexpr bool is_arithmetic_v = is_arithmetic<T>::value;
+
+template <class T> struct is_scalar : public bool_constant<__is_scalar(T)> {};
+
+template <class T> inline constexpr bool is_scalar_v = is_scalar<T>::value;
+
+template <class T> struct is_object : public bool_constant<__is_object(T)> {};
+
+template <class T> inline constexpr bool is_object_v = is_object<T>::value;
+
+template <class T>
+struct is_compound : public bool_constant<__is_compound(T)> {};
+
+template <class T> inline constexpr bool is_compound_v = is_compound<T>::value;
+
+template <class T>
+struct is_reference : public bool_constant<__is_reference(T)> {};
+
+template <class T>
+inline constexpr bool is_reference_v = is_reference<T>::value;
+
+template <class T>
+struct is_member_pointer : public bool_constant<__is_member_pointer(T)> {};
+
+template <class T>
+inline constexpr bool is_member_pointer_v = is_member_pointer<T>::value;
+
+template <class T> struct is_const : public bool_constant<__is_const(T)> {};
+
+template <class T> inline constexpr bool is_const_v = is_const<T>::value;
+
+template <class T>
+struct is_volatile : public bool_constant<__is_volatile(T)> {};
+
+template <class T> inline constexpr bool is_volatile_v = is_volatile<T>::value;
+
+template <class T> struct is_trivial : public bool_constant<__is_trivial(T)> {};
+
+template <class T> inline constexpr bool is_trivial_v = is_trivial<T>::value;
+
+template <class T>
+struct is_trivially_copyable
+    : public bool_constant<__is_trivially_copyable(T)> {};
+
+template <class T>
+inline constexpr bool is_trivially_copyable_v = is_trivially_copyable<T>::value;
+
+template <class T>
+struct is_standard_layout : public bool_constant<__is_standard_layout(T)> {};
+
+template <class T>
+inline constexpr bool is_standard_layout_v = is_standard_layout<T>::value;
+
+template <class T>
+struct has_unique_object_representations
+    : public bool_constant<__has_unique_object_representations(T)> {};
+
+template <class T>
+inline constexpr bool has_unique_object_representations_v =
+    has_unique_object_representations<T>::value;
+
+template <class T> struct is_empty : public bool_constant<__is_empty(T)> {};
+
+template <class T> inline constexpr bool is_empty_v = is_empty<T>::value;
+
+template <class T>
+struct is_polymorphic : public bool_constant<__is_polymorphic(T)> {};
+
+template <class T>
+inline constexpr bool is_polymorphic_v = is_polymorphic<T>::value;
+
+template <class T>
+struct is_abstract : public bool_constant<__is_abstract(T)> {};
+
+template <class T> inline constexpr bool is_abstract_v = is_abstract<T>::value;
+
+template <class T> struct is_final : public bool_constant<__is_final(T)> {};
+
+template <class T> inline constexpr bool is_final_v = is_final<T>::value;
+
+template <class T>
+struct is_aggregate : public bool_constant<__is_aggregate(T)> {};
+
+template <class T>
+inline constexpr bool is_aggregate_v = is_aggregate<T>::value;
+
+template <class T>
+struct is_signed : public bool_constant<__is_signed(T)> {};
+
+template <class T>
+inline constexpr bool is_signed_v = is_signed<T>::value;
+
+template <class T>
+struct is_unsigned : public bool_constant<__is_unsigned(T)> {};
+
+template <class T> inline constexpr bool is_unsigned_v = is_unsigned<T>::value;
+
+template <class T, class... Args>
+struct is_constructible : public bool_constant<__is_constructible(T, Args...)> {
+};
+
+template <class T, class... Args>
+inline constexpr bool is_constructible_v = is_constructible<T, Args...>::value;
+
+template <class T, class... Args>
+struct is_trivially_constructible
+    : public bool_constant<__is_trivially_constructible(T, Args...)> {};
+
+template <class T, class... Args>
+inline constexpr bool is_trivially_constructible_v =
+    is_trivially_constructible<T, Args...>::value;
+
+template <class T, class... Args>
+struct is_nothrow_constructible
+    : public bool_constant<__is_nothrow_constructible(T, Args...)> {};
+
+template <class T, class... Args>
+inline constexpr bool is_nothrow_constructible_v =
+    is_nothrow_constructible<T, Args...>::value;
+
+template <class T>
+struct is_default_constructible : public is_constructible<T> {};
+
+template <class T>
+struct is_trivially_default_constructible : public is_trivially_constructible<T> {};
+
+template <class T>
+struct is_nothrow_default_constructible : public is_nothrow_constructible<T> {};
+
+template <class T>
+inline constexpr bool is_default_constructible_v =
+    is_default_constructible<T>::value;
+
+template <class T>
+inline constexpr bool is_trivially_default_constructible_v =
+    is_trivially_default_constructible<T>::value;
+
+template <class T>
+inline constexpr bool is_nothrow_default_constructible_v =
+    is_nothrow_default_constructible<T>::value;
+
+template <class T>
+struct is_copy_constructible
+    : is_constructible<T, add_lvalue_reference_t<add_const_t<T>>> {};
+
+template <class T>
+struct is_trivially_copy_constructible
+    : is_trivially_constructible<T, add_lvalue_reference_t<add_const_t<T>>> {};
+
+template <class T>
+struct is_nothrow_copy_constructible
+    : is_nothrow_constructible<T, add_lvalue_reference_t<add_const_t<T>>> {};
+
+template <class T>
+inline constexpr bool is_copy_constructible_v = is_copy_constructible<T>::value;
+
+template <class T>
+inline constexpr bool is_trivially_copy_constructible_v =
+    is_trivially_copy_constructible<T>::value;
+
+template <class T>
+inline constexpr bool is_nothrow_copy_constructible_v =
+    is_nothrow_copy_constructible<T>::value;
+
+template <class T>
+struct is_move_constructible : is_constructible<T, add_rvalue_reference_t<T>> {
+};
+
+template <class T>
+struct is_trivially_move_constructible
+    : is_trivially_constructible<T, add_rvalue_reference_t<T>> {};
+
+template <class T>
+struct is_nothrow_move_constructible
+    : is_nothrow_constructible<T, add_rvalue_reference_t<T>> {};
+
+template <class T>
+inline constexpr bool is_move_constructible_v = is_move_constructible<T>::value;
+
+template <class T>
+inline constexpr bool is_trivially_move_constructible_v =
+    is_trivially_move_constructible<T>::value;
+
+template <class T>
+inline constexpr bool is_nothrow_move_constructible_v =
+    is_nothrow_move_constructible<T>::value;
+
+template <class T, class... Args>
+struct is_assignable : public bool_constant<__is_assignable(T, Args...)> {
+};
+
+template <class T, class... Args>
+inline constexpr bool is_assignable_v = is_assignable<T, Args...>::value;
+
+template <class T, class... Args>
+struct is_trivially_assignable
+    : public bool_constant<__is_trivially_assignable(T, Args...)> {};
+
+template <class T, class... Args>
+inline constexpr bool is_trivially_assignable_v =
+    is_trivially_assignable<T, Args...>::value;
+
+template <class T, class... Args>
+struct is_nothrow_assignable
+    : public bool_constant<__is_nothrow_assignable(T, Args...)> {};
+
+template <class T, class... Args>
+inline constexpr bool is_nothrow_assignable_v =
+    is_nothrow_assignable<T, Args...>::value;
+
+template <class T>
+struct is_copy_assignable : is_assignable<add_lvalue_reference_t<T>,
+                                          add_lvalue_reference_t<const T>> {};
+
+template <class T>
+struct is_trivially_copy_assignable
+    : is_trivially_assignable<add_lvalue_reference_t<T>,
+                              add_lvalue_reference_t<const T>> {};
+
+template <class T>
+struct is_nothrow_copy_assignable
+    : is_nothrow_assignable<add_lvalue_reference_t<T>,
+                            add_lvalue_reference_t<const T>> {};
+
+template <class T>
+inline constexpr bool is_copy_assignable_v = is_copy_assignable<T>::value;
+
+template <class T>
+inline constexpr bool is_trivially_copy_assignable_v =
+    is_trivially_copy_assignable<T>::value;
+
+template <class T>
+inline constexpr bool is_nothrow_copy_assignable_v =
+    is_nothrow_copy_assignable<T>::value;
+
+template <class T>
+struct is_move_assignable
+    : is_assignable<add_lvalue_reference_t<T>, add_rvalue_reference_t<T>> {};
+
+template <class T>
+struct is_trivially_move_assignable
+    : is_trivially_assignable<add_lvalue_reference_t<T>,
+                              add_rvalue_reference_t<T>> {};
+
+template <class T>
+struct is_nothrow_move_assignable
+    : is_nothrow_assignable<add_lvalue_reference_t<T>,
+                            add_rvalue_reference_t<T>> {};
+
+template <class T>
+inline constexpr bool is_move_assignable_v = is_move_assignable<T>::value;
+
+template <class T>
+inline constexpr bool is_trivially_move_assignable_v =
+    is_trivially_move_assignable<T>::value;
+
+template <class T>
+inline constexpr bool is_nothrow_move_assignable_v =
+    is_nothrow_move_assignable<T>::value;
+
+//  if it's a reference, return true
+//  if it's a function, return false
+//  if it's   void,     return false
+//  if it's an array of unknown bound, return false
+//  Otherwise, return "declval<_Up&>().~_Up()" is well-formed
+//    where _Up is remove_all_extents<_Tp>::type
+
+template <class> struct __is_destructible_apply { typedef int type; };
+
+struct __two {
+  char __lx[2];
+};
+
+template <typename _Tp> struct __is_destructor_wellformed {
+  template <typename _Tp1>
+  static char __test(typename __is_destructible_apply<
+                     decltype(declval<_Tp1 &>().~_Tp1())>::type);
+
+  template <typename _Tp1> static __two __test(...);
+
+  static const bool value = sizeof(__test<_Tp>(12)) == sizeof(char);
+};
+
+template <class _Tp, bool> struct __destructible_imp;
+
+template <class _Tp>
+struct __destructible_imp<_Tp, false>
+    : public bool_constant<
+          __is_destructor_wellformed<remove_all_extents_t<_Tp>>::value> {};
+
+template <class _Tp> struct __destructible_imp<_Tp, true> : public true_type {};
+
+template <class _Tp, bool> struct __destructible_nonfunction;
+
+template <class _Tp>
+struct __destructible_nonfunction<_Tp, false>
+    : public __destructible_imp<_Tp, is_reference_v<_Tp>> {};
+
+template <class _Tp>
+struct __destructible_nonfunction<_Tp, true> : public false_type {};
+
+template <class _Tp>
+struct is_destructible
+    : public __destructible_nonfunction<_Tp, is_function_v<_Tp>> {};
+
+template <class _Tp> struct is_destructible<_Tp[]> : public false_type {};
+
+template <> struct is_destructible<void> : public false_type {};
+
+template <class _Tp>
+inline constexpr bool is_destructible_v = is_destructible<_Tp>::value;
+
+template <class T>
+struct is_trivially_destructible
+    : public bool_constant<__is_trivially_constructible(T)> {};
+
+template <class _Tp>
+inline constexpr bool is_trivially_destructible_v =
+    is_trivially_destructible<_Tp>::value;
+
+template <bool, class _Tp> struct __libcpp_is_nothrow_destructible;
+
+template <class _Tp>
+struct __libcpp_is_nothrow_destructible<false, _Tp> : public false_type {};
+
+template <class _Tp>
+struct __libcpp_is_nothrow_destructible<true, _Tp>
+    : public integral_constant<bool, noexcept(declval<_Tp>().~_Tp())> {};
+
+template <class _Tp>
+struct is_nothrow_destructible
+    : public __libcpp_is_nothrow_destructible<is_destructible_v<_Tp>, _Tp> {};
+
+template <class _Tp, size_t _Ns>
+struct is_nothrow_destructible<_Tp[_Ns]> : public is_nothrow_destructible<_Tp> {
+};
+
+template <class _Tp>
+struct is_nothrow_destructible<_Tp &> : public true_type {};
+
+template <class _Tp>
+struct is_nothrow_destructible<_Tp &&> : public true_type {};
+
+template <class _Tp>
+inline constexpr bool is_nothrow_destructible_v =
+    is_nothrow_destructible<_Tp>::value;
+
+template <class T>
+struct has_virtual_destructor
+    : public bool_constant<__has_virtual_destructor(T)> {};
+
+template <class _Tp>
+inline constexpr bool has_virtual_destructor_v =
+    has_virtual_destructor<_Tp>::value;
+
+template <class _Tp> struct __is_swappable;
+template <class _Tp> struct __is_nothrow_swappable;
+
+template <class _Tp>
+using __swap_result_t =
+    enable_if_t<is_move_constructible_v<_Tp> && is_move_assignable_v<_Tp>>;
+
+template <class _Tp>
+inline constexpr __swap_result_t<_Tp> swap(_Tp &__x, _Tp &__y) noexcept(
+    is_nothrow_move_constructible_v<_Tp> &&is_nothrow_move_assignable_v<_Tp>);
+
+template <class _Tp, size_t _Np>
+inline constexpr enable_if_t<__is_swappable<_Tp>::value>
+    swap(_Tp (&__a)[_Np],
+         _Tp (&__b)[_Np]) noexcept(__is_nothrow_swappable<_Tp>::value);
+
+struct __is_referenceable_impl {
+  template <class _Tp> static _Tp &__test(int);
+  template <class _Tp> static __two __test(...);
+};
+
+template <class _Tp>
+struct __is_referenceable
+    : bool_constant<!is_same_v<
+          decltype(__is_referenceable_impl::__test<_Tp>(0)), __two>> {};
+
+namespace __detail {
+// ALL generic swap overloads MUST already have a declaration available at this
+// point.
+
+template <class _Tp, class _Up = _Tp,
+          bool _NotVoid = !is_void_v<_Tp> && !is_void_v<_Up>>
+struct __swappable_with {
+  template <class _LHS, class _RHS>
+  static decltype(swap(declval<_LHS>(), declval<_RHS>())) __test_swap(int);
+  template <class, class> static __nat __test_swap(long);
+
+  // Extra parens are needed for the C++03 definition of decltype.
+  typedef decltype((__test_swap<_Tp, _Up>(0))) __swap1;
+  typedef decltype((__test_swap<_Up, _Tp>(0))) __swap2;
+
+  static const bool value =
+      !is_same_v<__swap1, __nat> && !is_same_v<__swap2, __nat>;
+};
+
+template <class _Tp, class _Up>
+struct __swappable_with<_Tp, _Up, false> : false_type {};
+
+template <class _Tp, class _Up = _Tp,
+          bool _Swappable = __swappable_with<_Tp, _Up>::value>
+struct __nothrow_swappable_with {
+  static const bool value =
+      noexcept(swap(declval<_Tp>(), declval<_Up>())) &&noexcept(
+          swap(declval<_Up>(), declval<_Tp>()));
+};
+
+template <class _Tp, class _Up>
+struct __nothrow_swappable_with<_Tp, _Up, false> : false_type {};
+
+} // namespace __detail
+
+template <class _Tp>
+struct __is_swappable
+    : public bool_constant<__detail::__swappable_with<_Tp &>::value> {};
+
+template <class _Tp>
+struct __is_nothrow_swappable
+    : public bool_constant<__detail::__nothrow_swappable_with<_Tp &>::value> {};
+
+template <class _Tp, class _Up>
+struct is_swappable_with
+    : public bool_constant<__detail::__swappable_with<_Tp, _Up>::value> {};
+
+template <class _Tp>
+struct is_swappable
+    : public conditional_t<__is_referenceable<_Tp>::value,
+                           is_swappable_with<add_lvalue_reference_t<_Tp>,
+                                             add_lvalue_reference_t<_Tp>>,
+                           false_type> {};
+
+template <class _Tp, class _Up>
+struct is_nothrow_swappable_with
+    : public bool_constant<
+          __detail::__nothrow_swappable_with<_Tp, _Up>::value> {};
+
+template <class _Tp>
+struct is_nothrow_swappable
+    : public conditional_t<
+          __is_referenceable<_Tp>::value,
+          is_nothrow_swappable_with<add_lvalue_reference_t<_Tp>,
+                                    add_lvalue_reference_t<_Tp>>,
+          false_type> {};
+
+template <class _Tp, class _Up>
+inline constexpr bool is_swappable_with_v = is_swappable_with<_Tp, _Up>::value;
+
+template <class _Tp>
+inline constexpr bool is_swappable_v = is_swappable<_Tp>::value;
+
+template <class _Tp, class _Up>
+inline constexpr bool is_nothrow_swappable_with_v =
+    is_nothrow_swappable_with<_Tp, _Up>::value;
+
+template <class _Tp>
+inline constexpr bool is_nothrow_swappable_v = is_nothrow_swappable<_Tp>::value;
+
+template <class T>
+struct alignment_of : integral_constant<size_t, alignof(T)> {};
+
+template <class T>
+inline constexpr size_t alignment_of_v = alignment_of<T>::value;
+
+template <class T>
+struct rank : public integral_constant<size_t, 0> {};
+
+template <class T>
+struct rank<T[]>
+    : public integral_constant<size_t, rank<T>::value + 1> {};
+
+template <class T, size_t N>
+struct rank<T[N]>
+    : public integral_constant<size_t, rank<T>::value + 1> {};
+
+template <class T> inline constexpr size_t rank_v = rank<T>::value;
+
+template <class T, unsigned N = 0>
+struct extent : public integral_constant<size_t, __array_extent(T, N)> {};
+
+template <class T, unsigned N = 0>
+inline constexpr std::size_t extent_v = extent<T, N>::value;
+
+template <class T, class U>
+struct is_base_of : public bool_constant<__is_base_of(T, U)> {};
+
+template <class T, class U>
+inline constexpr bool is_base_of_v = is_base_of<T, U>::value;
+
+template <class T, class U>
+struct is_convertible : public bool_constant<__is_convertible(T, U)> {};
+
+template <class T, class U>
+inline constexpr bool is_convertible_v = is_convertible<T, U>::value;
+
+template <class T> struct decay {
+private:
+  typedef remove_reference_t<T> U;
+
+public:
+  typedef conditional_t<
+      is_array_v<U>, remove_extent_t<U> *,
+      conditional_t<is_function_v<U>, add_pointer_t<U>, remove_cv_t<U>>>
+      type;
+};
+
+template <class T> using decay_t = typename decay<T>::type;
+
+template <class _DecayedFp> struct __member_pointer_class_type {};
+
+template <class _Ret, class _ClassType>
+struct __member_pointer_class_type<_Ret _ClassType::*> {
+  typedef _ClassType type;
+};
+
+template <class _Fp, class _A0, class _DecayFp = decay_t<_Fp>,
+          class _DecayA0 = decay_t<_A0>,
+          class _ClassT = typename __member_pointer_class_type<_DecayFp>::type>
+using __enable_if_bullet1 =
+    enable_if_t<is_member_function_pointer_v<_DecayFp> &&
+                is_base_of_v<_ClassT, _DecayA0>>;
+
+namespace __detail {
+template <class T> constexpr T &FUN(T &t) noexcept { return t; }
+template <class T> void FUN(T &&) = delete;
+} // namespace detail
+
+template <class T> class reference_wrapper;
+
+template <class _Tp> struct __is_reference_wrapper_impl : public false_type {};
+template <class _Tp>
+struct __is_reference_wrapper_impl<reference_wrapper<_Tp>> : public true_type {
+};
+template <class _Tp>
+struct __is_reference_wrapper
+    : public __is_reference_wrapper_impl<remove_cv_t<_Tp>> {};
+
+template <class _Fp, class _A0, class _DecayFp = decay_t<_Fp>,
+          class _DecayA0 = decay_t<_A0>>
+using __enable_if_bullet2 =
+    enable_if_t<is_member_function_pointer_v<_DecayFp> &&
+                __is_reference_wrapper<_DecayA0>::value>;
+
+template <class _Fp, class _A0, class _DecayFp = decay_t<_Fp>,
+          class _DecayA0 = decay_t<_A0>,
+          class _ClassT = typename __member_pointer_class_type<_DecayFp>::type>
+using __enable_if_bullet3 =
+    enable_if_t<is_member_function_pointer_v<_DecayFp> &&
+                !is_base_of_v<_ClassT, _DecayA0> &&
+                !__is_reference_wrapper<_DecayA0>::value>;
+
+template <class _Fp, class _A0, class _DecayFp = decay_t<_Fp>,
+          class _DecayA0 = decay_t<_A0>,
+          class _ClassT = typename __member_pointer_class_type<_DecayFp>::type>
+using __enable_if_bullet4 = enable_if_t<is_member_object_pointer_v<_DecayFp> &&
+                                        is_base_of_v<_ClassT, _DecayA0>>;
+
+template <class _Fp, class _A0, class _DecayFp = decay_t<_Fp>,
+          class _DecayA0 = decay_t<_A0>>
+using __enable_if_bullet5 =
+    enable_if_t<is_member_object_pointer_v<_DecayFp> &&
+                __is_reference_wrapper<_DecayA0>::value>;
+
+template <class _Fp, class _A0, class _DecayFp = decay_t<_Fp>,
+          class _DecayA0 = decay_t<_A0>,
+          class _ClassT = typename __member_pointer_class_type<_DecayFp>::type>
+using __enable_if_bullet6 =
+    enable_if_t<is_member_object_pointer_v<_DecayFp> &&
+                !is_base_of_v<_ClassT, _DecayA0> &&
+                !__is_reference_wrapper<_DecayA0>::value>;
+
+// __invoke forward declarations
+
+// fall back - none of the bullets
+
+struct __any {
+  __any(...);
+};
+
+template <class... _Args> auto __invoke(__any, _Args &&...__args) -> __nat;
+
+template <class... _Args>
+auto __invoke_constexpr(__any, _Args &&...__args) -> __nat;
+
+// bullets 1, 2 and 3
+
+template <class _Fp, class _A0, class... _Args,
+          class = __enable_if_bullet1<_Fp, _A0>>
+inline constexpr auto
+__invoke(_Fp &&__f, _A0 &&__a0, _Args &&...__args) noexcept(noexcept(
+    (static_cast<_A0 &&>(__a0).*__f)(static_cast<_Args &&>(__args)...)))
+    -> decltype((static_cast<_A0 &&>(__a0).*
+                 __f)(static_cast<_Args &&>(__args)...)) {
+  return (static_cast<_A0 &&>(__a0).*__f)(static_cast<_Args &&>(__args)...);
+}
+
+template <class _Fp, class _A0, class... _Args,
+          class = __enable_if_bullet1<_Fp, _A0>>
+inline constexpr auto
+__invoke_constexpr(_Fp &&__f, _A0 &&__a0, _Args &&...__args) noexcept(noexcept(
+    (static_cast<_A0 &&>(__a0).*__f)(static_cast<_Args &&>(__args)...)))
+    -> decltype((static_cast<_A0 &&>(__a0).*
+                 __f)(static_cast<_Args &&>(__args)...)) {
+  return (static_cast<_A0 &&>(__a0).*__f)(static_cast<_Args &&>(__args)...);
+}
+
+template <class _Fp, class _A0, class... _Args,
+          class = __enable_if_bullet2<_Fp, _A0>>
+inline constexpr auto
+__invoke(_Fp &&__f, _A0 &&__a0, _Args &&...__args) noexcept(
+    noexcept((__a0.get().*__f)(static_cast<_Args &&>(__args)...)))
+    -> decltype((__a0.get().*__f)(static_cast<_Args &&>(__args)...)) {
+  return (__a0.get().*__f)(static_cast<_Args &&>(__args)...);
+}
+
+template <class _Fp, class _A0, class... _Args,
+          class = __enable_if_bullet2<_Fp, _A0>>
+inline constexpr auto
+__invoke_constexpr(_Fp &&__f, _A0 &&__a0, _Args &&...__args) noexcept(
+    noexcept((__a0.get().*__f)(static_cast<_Args &&>(__args)...)))
+    -> decltype((__a0.get().*__f)(static_cast<_Args &&>(__args)...)) {
+  return (__a0.get().*__f)(static_cast<_Args &&>(__args)...);
+}
+
+template <class _Fp, class _A0, class... _Args,
+          class = __enable_if_bullet3<_Fp, _A0>>
+inline constexpr auto
+__invoke(_Fp &&__f, _A0 &&__a0, _Args &&...__args) noexcept(noexcept(
+    ((*static_cast<_A0 &&>(__a0)).*__f)(static_cast<_Args &&>(__args)...)))
+    -> decltype(((*static_cast<_A0 &&>(__a0)).*
+                 __f)(static_cast<_Args &&>(__args)...)) {
+  return ((*static_cast<_A0 &&>(__a0)).*__f)(static_cast<_Args &&>(__args)...);
+}
+
+template <class _Fp, class _A0, class... _Args,
+          class = __enable_if_bullet3<_Fp, _A0>>
+inline constexpr auto
+__invoke_constexpr(_Fp &&__f, _A0 &&__a0, _Args &&...__args) noexcept(noexcept(
+    ((*static_cast<_A0 &&>(__a0)).*__f)(static_cast<_Args &&>(__args)...)))
+    -> decltype(((*static_cast<_A0 &&>(__a0)).*
+                 __f)(static_cast<_Args &&>(__args)...)) {
+  return ((*static_cast<_A0 &&>(__a0)).*__f)(static_cast<_Args &&>(__args)...);
+}
+
+// // bullets 4, 5 and 6
+
+template <class _Fp, class _A0, class = __enable_if_bullet4<_Fp, _A0>>
+inline constexpr auto
+__invoke(_Fp &&__f,
+         _A0 &&__a0) noexcept(noexcept(static_cast<_A0 &&>(__a0).*__f))
+    -> decltype(static_cast<_A0 &&>(__a0).*__f) {
+  return static_cast<_A0 &&>(__a0).*__f;
+}
+
+template <class _Fp, class _A0, class = __enable_if_bullet4<_Fp, _A0>>
+inline constexpr auto __invoke_constexpr(_Fp &&__f, _A0 &&__a0) noexcept(
+    noexcept(static_cast<_A0 &&>(__a0).*__f))
+    -> decltype(static_cast<_A0 &&>(__a0).*__f) {
+  return static_cast<_A0 &&>(__a0).*__f;
+}
+
+template <class _Fp, class _A0, class = __enable_if_bullet5<_Fp, _A0>>
+inline constexpr auto __invoke(_Fp &&__f,
+                               _A0 &&__a0) noexcept(noexcept(__a0.get().*__f))
+    -> decltype(__a0.get().*__f) {
+  return __a0.get().*__f;
+}
+
+template <class _Fp, class _A0, class = __enable_if_bullet5<_Fp, _A0>>
+inline constexpr auto
+__invoke_constexpr(_Fp &&__f, _A0 &&__a0) noexcept(noexcept(__a0.get().*__f))
+    -> decltype(__a0.get().*__f) {
+  return __a0.get().*__f;
+}
+
+template <class _Fp, class _A0, class = __enable_if_bullet6<_Fp, _A0>>
+inline constexpr auto
+__invoke(_Fp &&__f,
+         _A0 &&__a0) noexcept(noexcept((*static_cast<_A0 &&>(__a0)).*__f))
+    -> decltype((*static_cast<_A0 &&>(__a0)).*__f) {
+  return (*static_cast<_A0 &&>(__a0)).*__f;
+}
+
+template <class _Fp, class _A0, class = __enable_if_bullet6<_Fp, _A0>>
+inline constexpr auto __invoke_constexpr(_Fp &&__f, _A0 &&__a0) noexcept(
+    noexcept((*static_cast<_A0 &&>(__a0)).*__f))
+    -> decltype((*static_cast<_A0 &&>(__a0)).*__f) {
+  return (*static_cast<_A0 &&>(__a0)).*__f;
+}
+
+// bullet 7
+
+template <class _Fp, class... _Args>
+inline constexpr auto __invoke(_Fp &&__f, _Args &&...__args) noexcept(
+    noexcept(static_cast<_Fp &&>(__f)(static_cast<_Args &&>(__args)...)))
+    -> decltype(static_cast<_Fp &&>(__f)(static_cast<_Args &&>(__args)...)) {
+  return static_cast<_Fp &&>(__f)(static_cast<_Args &&>(__args)...);
+}
+
+template <class _Fp, class... _Args>
+inline constexpr auto __invoke_constexpr(_Fp &&__f, _Args &&...__args) noexcept(
+    noexcept(static_cast<_Fp &&>(__f)(static_cast<_Args &&>(__args)...)))
+    -> decltype(static_cast<_Fp &&>(__f)(static_cast<_Args &&>(__args)...)) {
+  return static_cast<_Fp &&>(__f)(static_cast<_Args &&>(__args)...);
+}
+
+// __invokable
+template <class _Ret, class _Fp, class... _Args> struct __invokable_r {
+  template <class _XFp, class... _XArgs>
+  static auto __try_call(int)
+      -> decltype(__invoke(declval<_XFp>(), declval<_XArgs>()...));
+  template <class _XFp, class... _XArgs> static __nat __try_call(...);
+
+  // FIXME: Check that _Ret, _Fp, and _Args... are all complete types, cv void,
+  // or incomplete array types as required by the standard.
+  using _Result = decltype(__try_call<_Fp, _Args...>(0));
+
+  using type = conditional_t<
+      !is_same_v<_Result, __nat>,
+      conditional_t<is_void_v<_Ret>, true_type, is_convertible<_Result, _Ret>>,
+      false_type>;
+  static const bool value = type::value;
+};
+template <class _Fp, class... _Args>
+using __invokable = __invokable_r<void, _Fp, _Args...>;
+
+template <bool _IsInvokable, bool _IsCVVoid, class _Ret, class _Fp,
+          class... _Args>
+struct __nothrow_invokable_r_imp {
+  static const bool value = false;
+};
+
+template <class _Ret, class _Fp, class... _Args>
+struct __nothrow_invokable_r_imp<true, false, _Ret, _Fp, _Args...> {
+  typedef __nothrow_invokable_r_imp _ThisT;
+
+  template <class _Tp> static void __test_noexcept(_Tp) noexcept;
+
+  static const bool value = noexcept(_ThisT::__test_noexcept<_Ret>(
+      __invoke(declval<_Fp>(), declval<_Args>()...)));
+};
+
+template <class _Ret, class _Fp, class... _Args>
+struct __nothrow_invokable_r_imp<true, true, _Ret, _Fp, _Args...> {
+  static const bool value =
+      noexcept(__invoke(declval<_Fp>(), declval<_Args>()...));
+};
+
+template <class _Ret, class _Fp, class... _Args>
+using __nothrow_invokable_r =
+    __nothrow_invokable_r_imp<__invokable_r<_Ret, _Fp, _Args...>::value,
+                              is_void_v<_Ret>, _Ret, _Fp, _Args...>;
+
+template <class _Fp, class... _Args>
+using __nothrow_invokable =
+    __nothrow_invokable_r_imp<__invokable<_Fp, _Args...>::value, true, void,
+                              _Fp, _Args...>;
+
+template <class _Fn, class... _Args>
+struct is_invocable
+    : bool_constant<__invokable<_Fn, _Args...>::value> {};
+
+template <class _Ret, class _Fn, class... _Args>
+struct is_invocable_r
+    : bool_constant<__invokable_r<_Ret, _Fn, _Args...>::value> {};
+
+template <class _Fn, class... _Args>
+inline constexpr bool is_invocable_v = is_invocable<_Fn, _Args...>::value;
+
+template <class _Ret, class _Fn, class... _Args>
+inline constexpr bool is_invocable_r_v =
+    is_invocable_r<_Ret, _Fn, _Args...>::value;
+
+// is_nothrow_invocable
+
+template <class _Fn, class... _Args>
+struct is_nothrow_invocable
+    : bool_constant<__nothrow_invokable<_Fn, _Args...>::value> {};
+
+template <class _Ret, class _Fn, class... _Args>
+struct is_nothrow_invocable_r
+    : bool_constant<__nothrow_invokable_r<_Ret, _Fn, _Args...>::value> {};
+
+template <class _Fn, class... _Args>
+inline constexpr bool is_nothrow_invocable_v =
+    is_nothrow_invocable<_Fn, _Args...>::value;
+
+template <class _Ret, class _Fn, class... _Args>
+inline constexpr bool is_nothrow_invocable_r_v =
+    is_nothrow_invocable_r<_Ret, _Fn, _Args...>::value;
+
+template <class _Hp, class _Tp> struct __type_list {
+  typedef _Hp _Head;
+  typedef _Tp _Tail;
+};
+
+typedef __type_list<
+    signed char,
+    __type_list<signed short,
+                __type_list<signed int,
+                            __type_list<signed long,
+                                        __type_list<signed long long, __nat>>>>>
+    __signed_types;
+
+typedef __type_list<
+    unsigned char,
+    __type_list<
+        unsigned short,
+        __type_list<unsigned int,
+                    __type_list<unsigned long,
+                                __type_list<unsigned long long, __nat>>>>>
+    __unsigned_types;
+
+template <class _TypeList, size_t _Size,
+          bool = _Size <= sizeof(typename _TypeList::_Head)>
+struct __find_first;
+
+template <class _Hp, class _Tp, size_t _Size>
+struct __find_first<__type_list<_Hp, _Tp>, _Size, true> {
+  typedef _Hp type;
+};
+
+template <class _Hp, class _Tp, size_t _Size>
+struct __find_first<__type_list<_Hp, _Tp>, _Size, false> {
+  typedef typename __find_first<_Tp, _Size>::type type;
+};
+
+template <class _Tp, class _Up,
+          bool = is_const<typename remove_reference<_Tp>::type>::value,
+          bool = is_volatile<typename remove_reference<_Tp>::type>::value>
+struct __apply_cv {
+  typedef _Up type;
+};
+
+template <class _Tp, class _Up> struct __apply_cv<_Tp, _Up, true, false> {
+  typedef const _Up type;
+};
+
+template <class _Tp, class _Up> struct __apply_cv<_Tp, _Up, false, true> {
+  typedef volatile _Up type;
+};
+
+template <class _Tp, class _Up> struct __apply_cv<_Tp, _Up, true, true> {
+  typedef const volatile _Up type;
+};
+
+template <class _Tp, class _Up> struct __apply_cv<_Tp &, _Up, false, false> {
+  typedef _Up &type;
+};
+
+template <class _Tp, class _Up> struct __apply_cv<_Tp &, _Up, true, false> {
+  typedef const _Up &type;
+};
+
+template <class _Tp, class _Up> struct __apply_cv<_Tp &, _Up, false, true> {
+  typedef volatile _Up &type;
+};
+
+template <class _Tp, class _Up> struct __apply_cv<_Tp &, _Up, true, true> {
+  typedef const volatile _Up &type;
+};
+
+template <class _Tp, bool = is_integral<_Tp>::value || is_enum<_Tp>::value>
+struct __make_signed {};
+
+template <class _Tp> struct __make_signed<_Tp, true> {
+  typedef typename __find_first<__signed_types, sizeof(_Tp)>::type type;
+};
+
+template <> struct __make_signed<bool, true> {};
+template <> struct __make_signed<signed short, true> { typedef short type; };
+template <> struct __make_signed<unsigned short, true> { typedef short type; };
+template <> struct __make_signed<signed int, true> { typedef int type; };
+template <> struct __make_signed<unsigned int, true> { typedef int type; };
+template <> struct __make_signed<signed long, true> { typedef long type; };
+template <> struct __make_signed<unsigned long, true> { typedef long type; };
+template <> struct __make_signed<signed long long, true> {
+  typedef long long type;
+};
+template <> struct __make_signed<unsigned long long, true> {
+  typedef long long type;
+};
+
+template <class _Tp> struct make_signed {
+  typedef typename __apply_cv<
+      _Tp, typename __make_signed<remove_cv_t<_Tp>>::type>::type type;
+};
+template <class _Tp> using make_signed_t = typename make_signed<_Tp>::type;
+
+template <class _Tp, bool = is_integral<_Tp>::value || is_enum<_Tp>::value>
+struct __make_unsigned {};
+
+template <class _Tp> struct __make_unsigned<_Tp, true> {
+  typedef typename __find_first<__unsigned_types, sizeof(_Tp)>::type type;
+};
+
+template <> struct __make_unsigned<bool, true> {};
+template <> struct __make_unsigned<signed short, true> {
+  typedef unsigned short type;
+};
+template <> struct __make_unsigned<unsigned short, true> {
+  typedef unsigned short type;
+};
+template <> struct __make_unsigned<signed int, true> {
+  typedef unsigned int type;
+};
+template <> struct __make_unsigned<unsigned int, true> {
+  typedef unsigned int type;
+};
+template <> struct __make_unsigned<signed long, true> {
+  typedef unsigned long type;
+};
+template <> struct __make_unsigned<unsigned long, true> {
+  typedef unsigned long type;
+};
+template <> struct __make_unsigned<signed long long, true> {
+  typedef unsigned long long type;
+};
+template <> struct __make_unsigned<unsigned long long, true> {
+  typedef unsigned long long type;
+};
+
+template <class _Tp> struct make_unsigned {
+  typedef typename __apply_cv<
+      _Tp, typename __make_unsigned<remove_cv_t<_Tp>>::type>::type type;
+};
+
+template <class _Tp> using make_unsigned_t = typename make_unsigned<_Tp>::type;
+
+template <class...> using void_t = void;
+
+// primary template (used for zero types)
+template <class...> struct common_type {};
+
+//////// one type
+template <class T> struct common_type<T> : common_type<T, T> {};
+
+namespace __detail {
+
+template <class T1, class T2>
+using conditional_result_t =
+    decltype(false ? std::declval<T1>() : std::declval<T2>());
+
+template <class, class, class = void> struct decay_conditional_result {};
+template <class T1, class T2>
+struct decay_conditional_result<T1, T2, void_t<conditional_result_t<T1, T2>>>
+    : decay<conditional_result_t<T1, T2>> {};
+
+template <class T1, class T2, class = void>
+struct common_type_2_impl : decay_conditional_result<const T1 &, const T2 &> {};
+
+template <class T1, class T2>
+struct common_type_2_impl<T1, T2, void_t<conditional_result_t<T1, T2>>>
+    : decay_conditional_result<T1, T2> {};
+} // namespace __detail
+
+//////// two types
+template <class T1, class T2>
+struct common_type<T1, T2>
+    : conditional_t<is_same_v<T1, decay_t<T1>> && is_same_v<T2, decay_t<T2>>,
+                    __detail::common_type_2_impl<T1, T2>,
+                    common_type<decay_t<T1>, decay_t<T2>>> {};
+
+//////// 3+ types
+namespace __detail {
+template <class AlwaysVoid, class T1, class T2, class... R>
+struct common_type_multi_impl {};
+template <class T1, class T2, class... R>
+struct common_type_multi_impl<void_t<typename common_type<T1, T2>::type>, T1,
+                              T2, R...>
+    : common_type<typename common_type<T1, T2>::type, R...> {};
+} // namespace __detail
+
+template <class T1, class T2, class... R>
+struct common_type<T1, T2, R...>
+    : __detail::common_type_multi_impl<void, T1, T2, R...> {};
+
+template <class... T> using common_type_t = typename common_type<T...>::type;
+
+template <class _Tp, bool = is_enum_v<_Tp>> struct __underlying_type_impl;
+
+template <class _Tp> struct __underlying_type_impl<_Tp, false> {};
+
+template <class _Tp> struct __underlying_type_impl<_Tp, true> {
+  typedef __underlying_type(_Tp) type;
+};
+
+template <class _Tp>
+struct underlying_type : __underlying_type_impl<_Tp, is_enum_v<_Tp>> {};
+
+template <class _Tp>
+using underlying_type_t = typename underlying_type<_Tp>::type;
 
 } // namespace std
 


### PR DESCRIPTION
This is an implementation of type_traits as of c++17. 

Most of the type traits map directly to clang intrinsics, so they have simple definitions.

The more complex template meta programs are simplified versions of the libc++ definitions. The primary differences are removing support for non-clang compiler and pre-c++17 variants.