### PR TITLE
Add __attribute__((leaf)) to dodo api functions

### DIFF
--- a/mos-platform/dodo/api.h
+++ b/mos-platform/dodo/api.h
@@ -23,7 +23,8 @@ extern "C" {
  * f	byte	boolean that specifies whether or not to flip horizontally
  * m	mode	drawing mode, see below
  */
-void DRAW_SPRITE(byte *sprite, byte x, byte y, byte w, byte h, byte f, byte m);
+__attribute__((leaf)) void DRAW_SPRITE(byte *sprite, byte x, byte y, byte w,
+                                       byte h, byte f, byte m);
 /* normal, replaces everything underneath the sprite */
 #define DRAW_NOP 0x0
 /* logical OR, fastest mode */
@@ -34,7 +35,7 @@ void DRAW_SPRITE(byte *sprite, byte x, byte y, byte w, byte h, byte f, byte m);
 #define DRAW_XOR 0x4
 
 /* Push video memory to the OLED (expensive) */
-void DISPLAY();
+__attribute__((leaf)) void DISPLAY();
 
 /*
 Erases the rectangular portiion of the screen defined by the parameters. Note
@@ -46,7 +47,7 @@ y	byte	y coordinate
 w	byte	width
 h	byte	height, must be multiple of 8
 */
-void CLEAR_SPRITE(byte x, byte y, byte w, byte h);
+__attribute__((leaf)) void CLEAR_SPRITE(byte x, byte y, byte w, byte h);
 
 /*
 Sets a pixel to a specific color
@@ -55,7 +56,7 @@ x	byte	x coordinate
 y	byte	y coordinate
 c	byte	color, 0 for black, 1 for white
 */
-void SET_PIXEL(byte x, byte y, byte c);
+__attribute__((leaf)) void SET_PIXEL(byte x, byte y, byte c);
 
 /*
 Bresenham line algorithm
@@ -68,25 +69,26 @@ y1	byte	y coordinate of second point
 c	byte	color, 0 for black, 1 for white
 Note: Computationally expensive, it is recommended to draw lines sparingly.
 */
-void DRAW_LINE(byte x0, byte y0, byte x1, byte y1, byte c);
+__attribute__((leaf)) void DRAW_LINE(byte x0, byte y0, byte x1, byte y1,
+                                     byte c);
 
-void DELAY_MS(byte delay);
-void LED_ON();
-void LED_OFF();
+__attribute__((leaf)) void DELAY_MS(byte delay);
+__attribute__((leaf)) void LED_ON();
+__attribute__((leaf)) void LED_OFF();
 
 /* Waits for an interrupt to fire. WAIT() should be called at the end of the
  * game loop in order to synchronize the frame rate to a consistent 20 FPS.  */
-void WAIT();
+__attribute__((leaf)) void WAIT();
 
-void LOAD_MUSIC(byte *music);
-void PLAY_EFFECT(byte *effect);
-void PLAY_EFFECT_ONCE(byte *effect);
-void SPI_ENABLE();
-void SPI_DISABLE();
-void SPI_WRITE(byte v);
+__attribute__((leaf)) void LOAD_MUSIC(byte *music);
+__attribute__((leaf)) void PLAY_EFFECT(byte *effect);
+__attribute__((leaf)) void PLAY_EFFECT_ONCE(byte *effect);
+__attribute__((leaf)) void SPI_ENABLE();
+__attribute__((leaf)) void SPI_DISABLE();
+__attribute__((leaf)) void SPI_WRITE(byte v);
 
 /* Clear the graphics in video memory */
-void CLEAR();
+__attribute__((leaf)) void CLEAR();
 
 /*
 Copying the background back and forth between video memory and a buffer is
@@ -108,10 +110,11 @@ w	byte	width
 h	byte	height
 dir	byte	direction, 0 = vmem -> buffer, 1 = buffer -> vmem
 */
-void COPY_BACKGROUND(byte *data, byte x, byte y, byte w, byte h, byte dir);
+__attribute__((leaf)) void COPY_BACKGROUND(byte *data, byte x, byte y, byte w,
+                                           byte h, byte dir);
 
-void DRAW_STRING(const char *text);
-void SET_CURSOR(byte row, byte col);
+__attribute__((leaf)) void DRAW_STRING(const char *text);
+__attribute__((leaf)) void SET_CURSOR(byte row, byte col);
 
 /* Returns a byte that is packed with the button state. For each bit that is
  * unset the corresponding button is pushed.
@@ -123,15 +126,15 @@ void SET_CURSOR(byte row, byte col);
  * 5	16	a
  * 6	32	b
  */
-byte READ_BUTTONS();
+__attribute__((leaf)) byte READ_BUTTONS();
 
-void GET_PIXEL(byte x, byte y);
+__attribute__((leaf)) void GET_PIXEL(byte x, byte y);
 
-void GET_VERSION(byte *p);
-void CHECK_VERSION(byte major, byte minor, byte revision);
+__attribute__((leaf)) void GET_VERSION(byte *p);
+__attribute__((leaf)) void CHECK_VERSION(byte major, byte minor, byte revision);
 
-void LOAD_PERSISTENT(byte *buffer);
-void SAVE_PERSISTENT(byte *buffer);
+__attribute__((leaf)) void LOAD_PERSISTENT(byte *buffer);
+__attribute__((leaf)) void SAVE_PERSISTENT(byte *buffer);
 
 // This will spin forever if there is a version mismatch
 #define api_init() CHECK_VERSION(MAJOR, MINOR, REVISION)


### PR DESCRIPTION
None of the functions in the dodo api can call anything from the main
LTO unit, so annotate all of them.

Closes #62

See https://github.com/llvm-mos/llvm-mos/issues/210
