### PR TITLE
Add zp.ld to dodo's linker script

### DIFF
--- a/mos-platform/dodo/link.ld
+++ b/mos-platform/dodo/link.ld
@@ -9,6 +9,7 @@ MEMORY {
 }
 
 SECTIONS {
+    INCLUDE zp.ld
     /* dodo jumps to $5900 to start the game */
     .text 0x5900 : {
         INCLUDE text-sections.ld


### PR DESCRIPTION
Before this change, linking could fail with

```
ld.lld: error: undefined symbol: __zp_bss_size
```
