### PR TITLE
Add CPU definition to mega65 target

### DIFF
--- a/mos-platform/mega65/clang.cfg
+++ b/mos-platform/mega65/clang.cfg
@@ -1,1 +1,2 @@
 -D__MEGA65__
+-mcpu=mos65ce02


### PR DESCRIPTION
The 65ce02 is currently the closest match to the derived GS4510 used in the mega65.