### PR TITLE
Add cbm_k kernal wrapper functions to commodore libc

### DIFF
--- a/mos-platform/commodore/CMakeLists.txt
+++ b/mos-platform/commodore/CMakeLists.txt
@@ -24,6 +24,33 @@ add_platform_library(commodore-c
   chrout.c
   getchar.c
   putchar.c
+  acptr.s
+  basin.s
+  bsout.s
+  chkin.s
+  chrin.s
+  ciout.s 
+  ckout.s
+  clall.s
+  close.s
+  clrch.s
+  getin.s
+  iobase.s
+  listen.s
+  load.s
+  open.s
+  readst.s
+  save.s
+  scnkey.s
+  second.s
+  setlfs.s
+  setnam.s
+  talk.s
+  tksa.s
+  udtim.s
+  unlsn.s
+  untlk.s
+)
 )
 # abort is preemptively included if LTO is used, which pulls in _exit support
 # unneccessarily. It can also be called in an interrupt.

--- a/mos-platform/commodore/acptr.s
+++ b/mos-platform/commodore/acptr.s
@@ -1,0 +1,10 @@
+.text
+
+#include <cbm_kernal.inc>
+
+;
+; unsigned char cbm_k_acptr (void);
+;
+.global cbm_k_acptr
+cbm_k_acptr:
+	jmp ACPTR

--- a/mos-platform/commodore/basin.s
+++ b/mos-platform/commodore/basin.s
@@ -1,0 +1,10 @@
+.text
+
+#include <cbm_kernal.inc>
+;
+; unsigned char cbm_k_basin (void);
+;
+.global cbm_k_basin
+cbm_k_basin:
+	jmp BASIN
+	

--- a/mos-platform/commodore/bsout.s
+++ b/mos-platform/commodore/bsout.s
@@ -1,0 +1,10 @@
+.text
+
+#include <cbm_kernal.inc>
+
+;
+; void cbm_k_bsout (unsigned char C);
+;
+.global cbm_k_bsout
+cbm_k_bsout:
+	jmp $FFD2

--- a/mos-platform/commodore/cbm.h
+++ b/mos-platform/commodore/cbm.h
@@ -190,9 +190,6 @@ void waitvsync (void);
 /*                           CBM kernal functions                            */
 /*****************************************************************************/
 
-// TODO
-#if 0
-
 /* Constants to use with cbm_open() for openning a file for reading or
 ** writing without the need to append ",r" or ",w" to the filename.
 **
@@ -205,41 +202,38 @@ void waitvsync (void);
 /* Kernal-level functions */
 unsigned char cbm_k_acptr (void);
 unsigned char cbm_k_basin (void);
-void __fastcall__ cbm_k_bsout (unsigned char C);
-unsigned char __fastcall__ cbm_k_chkin (unsigned char FN);
+void cbm_k_bsout (unsigned char C);
+unsigned char cbm_k_chkin (unsigned char FN);
 unsigned char cbm_k_chrin (void);
-void __fastcall__ cbm_k_chrout (unsigned char C);
-void __fastcall__ cbm_k_ciout (unsigned char C);
-unsigned char __fastcall__ cbm_k_ckout (unsigned char FN);
+void cbm_k_chrout (unsigned char C);
+void cbm_k_ciout (unsigned char C);
+unsigned char cbm_k_ckout (unsigned char FN);
 void cbm_k_clall (void);
-void __fastcall__ cbm_k_close (unsigned char FN);
+void cbm_k_close (unsigned char FN);
 void cbm_k_clrch (void);
 unsigned char cbm_k_getin (void);
 unsigned cbm_k_iobase (void);
-void __fastcall__ cbm_k_listen (unsigned char dev);
-unsigned int __fastcall__ cbm_k_load(unsigned char flag, unsigned addr);
+void cbm_k_listen (unsigned char dev);
+unsigned int cbm_k_load(unsigned char flag, unsigned addr);
 unsigned char cbm_k_open (void);
 unsigned char cbm_k_readst (void);
-unsigned char __fastcall__ cbm_k_save(unsigned int start, unsigned int end);
+unsigned char cbm_k_save(unsigned int start, unsigned int end);
 void cbm_k_scnkey (void);
-void __fastcall__ cbm_k_second (unsigned char addr);
-void __fastcall__ cbm_k_setlfs (unsigned char LFN, unsigned char DEV,
+void cbm_k_second (unsigned char addr);
+void cbm_k_setlfs (unsigned char LFN, unsigned char DEV,
                                 unsigned char SA);
-void __fastcall__ cbm_k_setnam (const char* Name);
-void __fastcall__ cbm_k_settim (unsigned long timer);
-void __fastcall__ cbm_k_talk (unsigned char dev);
-void __fastcall__ cbm_k_tksa (unsigned char addr);
+void cbm_k_setnam (const char* Name);
+void cbm_k_settim (unsigned long timer);
+void cbm_k_talk (unsigned char dev);
+void cbm_k_tksa (unsigned char addr);
 void cbm_k_udtim (void);
 void cbm_k_unlsn (void);
 void cbm_k_untlk (void);
 
-#endif
 
 /*****************************************************************************/
 /*                       BASIC-like file I/O functions                       */
 /*****************************************************************************/
-
-
 
 /* The cbm_* I/O functions below set _oserror (see errno.h),
 ** in case of an error.

--- a/mos-platform/commodore/chkin.s
+++ b/mos-platform/commodore/chkin.s
@@ -1,0 +1,12 @@
+.text
+
+#include <cbm_kernal.inc>
+
+;
+; unsigned char cbm_k_chkin (unsigned char FN);
+;
+.global cbm_k_chkin
+cbm_k_chkin:
+	tax
+	jmp $FFC6
+	

--- a/mos-platform/commodore/chrin.s
+++ b/mos-platform/commodore/chrin.s
@@ -1,0 +1,10 @@
+.text
+
+#include <cbm_kernal.inc>
+
+;
+; unsigned char cbm_k_chrin (void);
+;
+.global cbm_k_chrin
+cbm_k_chrin:
+	jmp CHRIN

--- a/mos-platform/commodore/ciout.s
+++ b/mos-platform/commodore/ciout.s
@@ -1,0 +1,10 @@
+.text
+
+#include <cbm_kernal.inc>
+
+;
+; void cbm_k_ciout (unsigned char C);
+;
+.global cbm_k_ciout
+cbm_k_ciout:
+	jmp $FFA8

--- a/mos-platform/commodore/ckout.s
+++ b/mos-platform/commodore/ckout.s
@@ -1,0 +1,10 @@
+.text
+
+#include <cbm_kernal.inc>
+
+;
+; unsigned char cbm_k_ckout (unsigned char FN);
+;
+.global cbm_k_ckout
+cbm_k_ckout:
+	jmp $FFC9

--- a/mos-platform/commodore/clall.s
+++ b/mos-platform/commodore/clall.s
@@ -1,0 +1,10 @@
+.text
+
+#include <cbm_kernal.inc>
+
+;
+; void cbm_k_clall (void);
+;
+.global cbm_k_clall
+cbm_k_clall:
+	jmp $FFE7

--- a/mos-platform/commodore/close.s
+++ b/mos-platform/commodore/close.s
@@ -1,0 +1,10 @@
+.text
+
+#include <cbm_kernal.inc>
+
+;
+; void cbm_k_close (unsigned char FN);
+;
+.global cbm_k_close
+cbm_k_close:
+	jmp $FFC3

--- a/mos-platform/commodore/clrch.s
+++ b/mos-platform/commodore/clrch.s
@@ -1,0 +1,10 @@
+.text
+
+#include <cbm_kernal.inc>
+
+;
+; void cbm_k_clrch (void);
+;
+.global cbm_k_clrch
+cbm_k_clrch:
+	jmp $FFCC

--- a/mos-platform/commodore/getin.s
+++ b/mos-platform/commodore/getin.s
@@ -1,0 +1,10 @@
+.text
+
+#include <cbm_kernal.inc>
+
+;
+; unsigned char cbm_k_getin (void);
+;
+.global cbm_k_getin
+cbm_k_getin:
+	jmp GETIN

--- a/mos-platform/commodore/iobase.s
+++ b/mos-platform/commodore/iobase.s
@@ -1,0 +1,14 @@
+.text
+
+#include <cbm_kernal.inc>
+
+;
+; unsigned cbm_k_iobase (void);
+;
+.global cbm_k_iobase
+	jsr IOBASE
+	txa
+	sty __rc2
+	ldx __rc2
+	rts
+	

--- a/mos-platform/commodore/listen.s
+++ b/mos-platform/commodore/listen.s
@@ -1,0 +1,10 @@
+.text
+
+#include <cbm_kernal.inc>
+
+;
+; void cbm_k_listen (unsigned char dev);
+;
+.global cbm_k_listen
+cbm_k_listen:
+	jmp LISTEN

--- a/mos-platform/commodore/load.s
+++ b/mos-platform/commodore/load.s
@@ -1,0 +1,11 @@
+.text
+
+#include <cbm_kernal.inc>
+
+;
+; unsigned int cbm_k_load(unsigned char flag, unsigned addr);
+;
+.global cbm_k_load
+cbm_k_load:
+	ldy __rc2
+	jmp LOAD

--- a/mos-platform/commodore/open.s
+++ b/mos-platform/commodore/open.s
@@ -1,0 +1,10 @@
+.text
+
+#include <cbm_kernal.inc>
+
+;
+; unsigned char cbm_k_open (void);
+;
+.global cbm_k_open
+cbm_k_open:
+	jmp $FFC0

--- a/mos-platform/commodore/readst.s
+++ b/mos-platform/commodore/readst.s
@@ -1,0 +1,10 @@
+.text
+
+#include <cbm_kernal.inc>
+
+;
+; unsigned char cbm_k_readst (void);
+;
+.global cbm_k_readst
+cbm_k_readst:
+	jmp READST

--- a/mos-platform/commodore/save.s
+++ b/mos-platform/commodore/save.s
@@ -1,0 +1,19 @@
+.text
+
+#include <cbm_kernal.inc>
+
+__rs1 = __rc2
+__rs2 = __rc4 
+
+;
+; unsigned char cbm_k_save(unsigned int start, unsigned int end);
+;
+.global cbm_k_save
+cbm_k_save:
+	sta __rs2 
+	stx __rs2 + 1
+	ldx __rc2
+	ldy __rc2 + 1
+	lda #__rs2
+	jmp SAVE
+	

--- a/mos-platform/commodore/scnkey.s
+++ b/mos-platform/commodore/scnkey.s
@@ -1,0 +1,10 @@
+.text
+
+#include <cbm_kernal.inc>
+
+;
+; void cbm_k_scnkey (void);
+;
+.global cbm_k_scnkey
+cbm_k_scnkey: 
+	jmp $FF9F

--- a/mos-platform/commodore/second.s
+++ b/mos-platform/commodore/second.s
@@ -1,0 +1,10 @@
+.text
+
+#include <cbm_kernal.inc>
+
+;
+; void cbm_k_second (unsigned char addr);
+;
+.global cbm_k_second
+cbm_k_second:
+	jmp SECOND

--- a/mos-platform/commodore/setlfs.s
+++ b/mos-platform/commodore/setlfs.s
@@ -1,0 +1,11 @@
+.text
+
+#include <cbm_kernal.inc>
+
+;
+; void cbm_k_setlfs (unsigned char LFN, unsigned char DEV, unsigned char SA);
+;
+.global cbm_k_setlfs
+cbm_k_setlfs:
+	ldy __rc2
+	jmp SETLFS

--- a/mos-platform/commodore/setnam.s
+++ b/mos-platform/commodore/setnam.s
@@ -1,0 +1,22 @@
+.text
+
+#include <cbm_kernal.inc>
+__rs1 = __rc2
+
+;
+; void cbm_k_setnam (const char* Name);
+;	
+.global cbm_k_setnam
+cbm_k_setnam:
+	lda __rs1 
+	pha
+	lda __rs1 + 1
+	pha
+	jsr strlen
+	sta __rc2
+	pla 
+	tay
+	pla 
+	tax
+	lda __rc2
+	jmp SETNAM

--- a/mos-platform/commodore/talk.s
+++ b/mos-platform/commodore/talk.s
@@ -1,0 +1,10 @@
+.text
+
+#include <cbm_kernal.inc>
+
+;
+; void cbm_k_talk (unsigned char dev);
+;
+.global cbm_k_talk
+cbm_k_talk:
+	jmp $FFB4

--- a/mos-platform/commodore/tksa.s
+++ b/mos-platform/commodore/tksa.s
@@ -1,0 +1,10 @@
+.text
+
+#include <cbm_kernal.inc>
+
+;
+; void cbm_k_tksa (unsigned char addr);
+;
+.global cbm_k_tksa
+cbm_k_tksa: 
+	jmp $FF96

--- a/mos-platform/commodore/udtim.s
+++ b/mos-platform/commodore/udtim.s
@@ -1,0 +1,10 @@
+.text
+
+#include <cbm_kernal.inc>
+
+;
+; void cbm_k_udtim (void);
+;
+.global cbm_k_udtim
+cbm_k_udtim:
+	jmp $FFEA

--- a/mos-platform/commodore/unlsn.s
+++ b/mos-platform/commodore/unlsn.s
@@ -1,0 +1,10 @@
+.text
+
+#include <cbm_kernal.inc>
+
+;
+; void cbm_k_unlsn (void);
+;
+.global cbm_k_unlsn
+cbm_k_unlsn:
+	jmp $FFAE

--- a/mos-platform/commodore/untlk.s
+++ b/mos-platform/commodore/untlk.s
@@ -1,0 +1,10 @@
+.text
+
+#include <cbm_kernal.inc>
+
+;
+; void cbm_k_untlk (void);
+;
+.global cbm_k_untlk
+cbm_k_untlk:
+	jmp UNTLK


### PR DESCRIPTION
- Added assembly source for kernal wrapper functions
- Removed an ifdef that always evaluated to false to add back function headers in cbm.h
- Removed `__fastcall__` tag from cbm_k functions
- Added .s files for the kernal wrappers to the commodore libc