### PR TITLE
Check for the batch file version for mos-clang platforms

### DIFF
--- a/cmake/find-mos-compiler.cmake
+++ b/cmake/find-mos-compiler.cmake
@@ -34,6 +34,14 @@ function(find_mos_compiler compiler_var bin_name)
       return_found_bin()
     endif()
 
+    # If we are on windows, try and find the program as a batch script first
+    # By default, cmake doesn't consider `.bat` as an executable extension, but it will find it
+    # if we specify the name of the file exactly
+    if(WIN32)
+      find_program(found_bin ${bin_name}.bat NO_CACHE)
+      return_found_bin()
+    endif()
+
     # Finally attempt finding clang with cmake's default find logic.
     find_program(found_bin ${bin_name} NO_CACHE)
     set(${out_var} ${found_bin} PARENT_SCOPE)


### PR DESCRIPTION
On windows, cmake doesn't adhere to PATHEXT for determining what is executable, and has its own hardcoded list. So while `find_program` will happily append `.exe` when looking for the file, it will not automatically add `.bat`.

Since the `mos-clang` wrappers for each configuration are in batch files, this works around the limitation by searching for the specific compiler with `.bat` appended to it, allowing `find_program` to work as expected.