### PR TITLE
[C64] Increase available RAM to 50KB by swapping out BASIC ROM

### DIFF
--- a/mos-platform/c64/CMakeLists.txt
+++ b/mos-platform/c64/CMakeLists.txt
@@ -15,6 +15,7 @@ install(FILES link.ld TYPE LIB)
 install(FILES c64.inc DESTINATION ${ASMINCDIR})
 
 add_platform_object_file(c64-basic-header basic-header.o basic-header.S)
+add_platform_object_file(c64-unmap-basic unmap-basic.o unmap-basic.S)
 
 add_platform_library(c64-c kernal.S)
 target_include_directories(c64-c BEFORE PUBLIC .)

--- a/mos-platform/c64/link.ld
+++ b/mos-platform/c64/link.ld
@@ -6,13 +6,16 @@
  */
 
 MEMORY {
-    ram (rw) : ORIGIN = 0x0801, LENGTH = 0x97ff
+    ram (rw) : ORIGIN = 0x0801, LENGTH = 0xC7FF
 }
 
 INCLUDE commodore.ld
 
-/* Set initial soft stack address to end of BASIC area. (It grows down.) */
-__stack = 0x9FFF;
+INPUT(unmap-basic.o)
+
+/* With the BASIC ROM unmapped, set initial soft stack address to 
+ * right before the I/O mapped $D000-DFFF area. (It grows down.) */
+__stack = 0xCFFF;
 
 OUTPUT_FORMAT {
     /* Tells the C64 LOAD command where to place the file's contents. */

--- a/mos-platform/c64/unmap-basic.S
+++ b/mos-platform/c64/unmap-basic.S
@@ -1,0 +1,20 @@
+; Switch out the BASIC ROM bank from $A000 to $BFFF.
+; This opens up 50KB of contiguous RAM from $0801-$CFFF.
+; KERNAL ROM at $E000-$FFFF and I/O at $D000-$DFFF are still mapped.
+
+
+
+; bank switching needs to complete before any CRT initialization
+.section .init.010,"axR",@progbits
+        ldx #$2F ; restore default CPU I/O port data directions
+        stx 0    ;
+        ldx #$3E ; LORAM = 0
+        stx 1    ; switch out BASIC ROM at $A000-$BFFF for RAM
+
+
+
+; restore BASIC ROM after all other exit handlers have completed
+.section .fini.990,"axR", @progbits
+        ldx #$3F ; LORAM = 1
+        stx 1    ; switch in BASIC ROM at $A000-$BFFF
+

--- a/utils/elftocpm65/elf.h
+++ b/utils/elftocpm65/elf.h
@@ -491,7 +491,7 @@ typedef struct {
 	unsigned char	st_other;
 	Elf32_Half	st_shndx;	/* SHN_... */
 #if defined(__arm__) || defined(__arm64__)
-	uint32_t	st_arch_subinfo;
+	Elf32_Word	st_arch_subinfo;
 #endif
 } Elf32_Sym;
 
@@ -504,7 +504,7 @@ typedef struct {
 	Elf64_Addr	st_value;
 	Elf64_Xword	st_size;
 #if defined(__arm__) || defined(__arm64__)
-	uint32_t	st_arch_subinfo;
+	Elf64_Word	st_arch_subinfo;
 #endif
 } Elf64_Sym;
 #endif	/* defined(_LP64) || defined(_LONGLONG_TYPE) */


### PR DESCRIPTION
On the C64, there is very little reason to keep the BASIC ROM mapped when executing machine code. Switching out the BASIC ROM frees up $A000-$BFFF, and opens up contiguous access to the $C000-$CFFFF area for a total of 12KB of additional RAM.

In the future it would be nice to also have a configuration option to switch out the KERNAL ROM ($E000-$FFFF) and reimplement the KERNAL routines in software so you only use what you need.