### PR TITLE
Fix bug in cbm_k_open function

### DIFF
--- a/mos-platform/commodore/CMakeLists.txt
+++ b/mos-platform/commodore/CMakeLists.txt
@@ -31,7 +31,7 @@ add_platform_library(commodore-c
   cbm_k_chrin.c
   cbm_k_chrout.c
   cbm_k_ciout.c 
-  cbm_k_ckout.c
+  cbm_k_ckout.s
   cbm_k_clall.c
   cbm_k_close.c
   cbm_k_clrch.c

--- a/mos-platform/commodore/CMakeLists.txt
+++ b/mos-platform/commodore/CMakeLists.txt
@@ -39,7 +39,7 @@ add_platform_library(commodore-c
   cbm_k_iobase.s
   cbm_k_listen.c
   cbm_k_load.s
-  cbm_k_open.c
+  cbm_k_open.s
   cbm_k_readst.c
   cbm_k_save.s
   cbm_k_scnkey.c

--- a/mos-platform/commodore/cbm_k_chkin.s
+++ b/mos-platform/commodore/cbm_k_chkin.s
@@ -6,4 +6,8 @@
 .global cbm_k_chkin
 cbm_k_chkin:
 	tax
-	jmp __CHKIN
+	jsr __CHKIN
+	bcs some_error
+	lda #0 ; open was successful if .C = clear
+some_error:
+	rts

--- a/mos-platform/commodore/cbm_k_ckout.c
+++ b/mos-platform/commodore/cbm_k_ckout.c
@@ -1,5 +1,0 @@
-extern unsigned char __CKOUT(unsigned char FN);
-
-unsigned char cbm_k_ckout (unsigned char FN) {
-	return __CKOUT(FN);
-}

--- a/mos-platform/commodore/cbm_k_ckout.s
+++ b/mos-platform/commodore/cbm_k_ckout.s
@@ -1,0 +1,15 @@
+.include "imag.inc"
+.text
+
+;
+; unsigned char cbm_k_ckout(unsigned char FN);
+;
+.global cbm_k_ckout
+cbm_k_ckout:
+	tax
+	jsr __CKOUT
+	ldx #0
+	bcs someerror
+	lda #0
+someerror:
+	rts

--- a/mos-platform/commodore/cbm_k_load.s
+++ b/mos-platform/commodore/cbm_k_load.s
@@ -9,7 +9,7 @@
 cbm_k_load:
 	ldy __rc2
 	jsr __LOAD
-	bcs noerror
+	bcc noerror
 	; error code in a ;
 	ldx #0
 	rts

--- a/mos-platform/commodore/cbm_k_load.s
+++ b/mos-platform/commodore/cbm_k_load.s
@@ -8,4 +8,8 @@
 .global cbm_k_load
 cbm_k_load:
 	ldy __rc2
-	jmp __LOAD
+	jsr __LOAD
+	bcs someerror
+	lda #0
+someerror:
+	rts

--- a/mos-platform/commodore/cbm_k_load.s
+++ b/mos-platform/commodore/cbm_k_load.s
@@ -7,10 +7,12 @@
 ;
 .global cbm_k_load
 cbm_k_load:
+	sta __rc4
+	stx __rc5
 	ldy __rc2
 	jsr __LOAD
-	bcs someerror
-	lda #0
-	tax
-someerror:
+	bcs noerror
+	; error code in a ;
+	ldx #0
+noerror:
 	rts

--- a/mos-platform/commodore/cbm_k_load.s
+++ b/mos-platform/commodore/cbm_k_load.s
@@ -7,12 +7,14 @@
 ;
 .global cbm_k_load
 cbm_k_load:
-	sta __rc4
-	stx __rc5
 	ldy __rc2
 	jsr __LOAD
 	bcs noerror
 	; error code in a ;
 	ldx #0
+	rts
 noerror:
+	txa
+	sty __rc2
+	ldx __rc2
 	rts

--- a/mos-platform/commodore/cbm_k_load.s
+++ b/mos-platform/commodore/cbm_k_load.s
@@ -11,5 +11,6 @@ cbm_k_load:
 	jsr __LOAD
 	bcs someerror
 	lda #0
+	tax
 someerror:
 	rts

--- a/mos-platform/commodore/cbm_k_open.c
+++ b/mos-platform/commodore/cbm_k_open.c
@@ -1,5 +1,0 @@
-extern unsigned __OPEN(void);
-
-unsigned char cbm_k_open (void) {
-	return __OPEN();
-}

--- a/mos-platform/commodore/cbm_k_open.s
+++ b/mos-platform/commodore/cbm_k_open.s
@@ -7,7 +7,7 @@
 ;
 .global cbm_k_open
 cbm_k_open:
-	jsr OPEN
+	jsr __OPEN
 	bcs some_error
 	lda #0 ; open was successful if .C = clear
 some_error:

--- a/mos-platform/commodore/cbm_k_open.s
+++ b/mos-platform/commodore/cbm_k_open.s
@@ -1,0 +1,14 @@
+.include "imag.inc"
+
+.text
+
+;
+; unsigned char cbm_k_open(void);
+;
+.global cbm_k_open
+cbm_k_open:
+	jsr OPEN
+	bcs some_error
+	lda #0 ; open was successful if .C = clear
+some_error:
+	rts

--- a/mos-platform/commodore/cbm_k_save.s
+++ b/mos-platform/commodore/cbm_k_save.s
@@ -11,4 +11,8 @@ cbm_k_save:
 	ldx __rc2
 	ldy __rc3
 	lda #__rc4
-	jmp __SAVE
+	jsr __SAVE
+	bcs someerror
+	lda #0
+someerror:
+	rts


### PR DESCRIPTION
When the Commodore OPEN kernal routine returns with the carry flag clear, the OPEN should be treated as a success and the value of the accumulator disregarded. Previously, this was not implemented correctly. Now, if carry flag is clear on return from OPEN, 0 is returned to the caller of `cbm_k_open()` indicating a success. 
Thanks to @mlund for finding this (#99)