### PR TITLE
Fix a bug in the cpm65 linker script causing certain addresses not to be relocated.

### DIFF
--- a/mos-platform/cpm65/link.ld
+++ b/mos-platform/cpm65/link.ld
@@ -46,7 +46,9 @@ SECTIONS {
 		*(.zp.data .zp.data.*)
 		*(.zp.rodata .zp.rodata.*)
 	} >zp AT>ram :init
-	INCLUDE zp-data-symbols.ld
+	__zp_data_load_start = ADDR(.text) + 
+		(LOADADDR(.zp.data) - LOADADDR(.text));
+	__zp_data_size = SIZEOF(.zp.data);
 
 	.pblock (NOLOAD) : {
 		_pblock = .;


### PR DESCRIPTION
This is fallout from #106; turns out that LOADADDR() addresses are absolute. This meant that any address sourced from LOADADDR() doesn't get relocated, even when they should be. Specifically, this was causing the source for the initialised zero page to be read from the wrong location.

The solution is to use a pointer difference of LOADADDRs from the start of the binary to get the offset, and then add on the ADDR of the binary start, turning the symbol into a .text address.
