### PR TITLE
Update CPM65; add some missing ctype and string functions

### DIFF
--- a/mos-platform/common/c/ctype.c
+++ b/mos-platform/common/c/ctype.c
@@ -23,3 +23,13 @@ int toupper(int c) {
   return ch;
 }
 
+int isalnum(int c) {
+  return isalpha(c) || isdigit(c);
+}
+
+int isspace(int c) {
+  char ch = c;
+  return (ch == ' ') || (ch == '\t') || (ch == '\n') ||
+  	(ch == '\f') || (ch == '\r') || (ch == '\v');
+}
+

--- a/mos-platform/common/c/string.c
+++ b/mos-platform/common/c/string.c
@@ -42,9 +42,10 @@ __attribute__((weak)) int strncmp(const char *s1, const char *s2, size_t n) {
   }
 }
 
-__attribute__((weak)) char *strncpy(char *restrict s1, const char *restrict s2, size_t n) {
+__attribute__((weak)) char *strncpy(char *restrict s1, const char *restrict s2,
+                                    size_t n) {
   char *ret = s1;
-  for (;n ; ++s1, ++s2, --n) {
+  for (; n; ++s1, ++s2, --n) {
     *s1 = *s2;
     if (!*s2) {
       for (++s1, --n; n; ++s1, --n)
@@ -64,69 +65,59 @@ __attribute__((weak)) char *strrchr(const char *s, int c) {
   return (char *)last;
 }
 
-__attribute__((weak)) char* strrev(char* str)
-{
-    size_t len = strlen((const char*)str);
-    size_t i, j;
-    for (i = 0, j = len - 1; i < j; i++, j--)
-    {
-        char a = str[i];
-        str[i] = str[j];
-        str[j] = a;
-    }
-	return str;
+__attribute__((weak)) char *strrev(char *str) {
+  size_t len = strlen((const char *)str);
+  size_t i, j;
+  for (i = 0, j = len - 1; i < j; i++, j--) {
+    char a = str[i];
+    str[i] = str[j];
+    str[j] = a;
+  }
+  return str;
 }
 
-__attribute__((weak)) size_t strspn(const char* string, const char* in)
-{
-    const char *s1, *s2;
+__attribute__((weak)) size_t strspn(const char *string, const char *in) {
+  const char *s1, *s2;
 
-    for (s1 = string; *s1; s1++)
-    {
-        for (s2 = in; *s2 && *s2 != *s1; s2++)
-            ;
-        if (!*s2)
-            break;
-    }
-    return s1 - string;
+  for (s1 = string; *s1; s1++) {
+    for (s2 = in; *s2 && *s2 != *s1; s2++)
+      ;
+    if (!*s2)
+      break;
+  }
+  return s1 - string;
 }
 
-__attribute__((weak)) char* strpbrk(const char* string, const char* brk)
-{
-    while (*string)
-    {
-        const char* s1;
-        for (s1 = brk; *s1 && *s1 != *string; s1++)
-            ;
-        if (*s1)
-            return (char*)string;
-        string++;
-    }
-    return (char*)NULL;
+__attribute__((weak)) char *strpbrk(const char *string, const char *brk) {
+  while (*string) {
+    const char *s1;
+    for (s1 = brk; *s1 && *s1 != *string; s1++)
+      ;
+    if (*s1)
+      return (char *)string;
+    string++;
+  }
+  return (char *)NULL;
 }
 
-__attribute__((weak)) char* strtok(char* string, const char* separators)
-{
-    static char* savestring = NULL;
+__attribute__((weak)) char *strtok(char *string, const char *separators) {
+  static char *savestring = NULL;
 
+  if (string == NULL) {
+    string = savestring;
     if (string == NULL)
-    {
-        string = savestring;
-        if (string == NULL)
-            return (char*)NULL;
-    }
+      return (char *)NULL;
+  }
 
-    char* s1 = string + strspn(string, separators);
-    if (*s1 == '\0')
-    {
-        savestring = NULL;
-        return (char*)NULL;
-    }
+  char *s1 = string + strspn(string, separators);
+  if (!*s1) {
+    savestring = NULL;
+    return (char *)NULL;
+  }
 
-    char* s2 = strpbrk(s1, separators);
-    if (s2 != NULL)
-        *s2++ = '\0';
-    savestring = s2;
-    return s1;
+  char *s2 = strpbrk(s1, separators);
+  if (s2 != NULL)
+    *s2++ = '\0';
+  savestring = s2;
+  return s1;
 }
-

--- a/mos-platform/common/c/string.c
+++ b/mos-platform/common/c/string.c
@@ -67,8 +67,7 @@ __attribute__((weak)) char *strrchr(const char *s, int c) {
 
 __attribute__((weak)) char *strrev(char *str) {
   size_t len = strlen((const char *)str);
-  size_t i, j;
-  for (i = 0, j = len - 1; i < j; i++, j--) {
+  for (size_t i = 0, j = len - 1; i < j; i++, j--) {
     char a = str[i];
     str[i] = str[j];
     str[j] = a;

--- a/mos-platform/common/c/string.c
+++ b/mos-platform/common/c/string.c
@@ -63,3 +63,70 @@ __attribute__((weak)) char *strrchr(const char *s, int c) {
       last = s;
   return (char *)last;
 }
+
+__attribute__((weak)) char* strrev(char* str)
+{
+    size_t len = strlen((const char*)str);
+    size_t i, j;
+    for (i = 0, j = len - 1; i < j; i++, j--)
+    {
+        char a = str[i];
+        str[i] = str[j];
+        str[j] = a;
+    }
+	return str;
+}
+
+__attribute__((weak)) size_t strspn(const char* string, const char* in)
+{
+    const char *s1, *s2;
+
+    for (s1 = string; *s1; s1++)
+    {
+        for (s2 = in; *s2 && *s2 != *s1; s2++)
+            ;
+        if (!*s2)
+            break;
+    }
+    return s1 - string;
+}
+
+__attribute__((weak)) char* strpbrk(const char* string, const char* brk)
+{
+    while (*string)
+    {
+        const char* s1;
+        for (s1 = brk; *s1 && *s1 != *string; s1++)
+            ;
+        if (*s1)
+            return (char*)string;
+        string++;
+    }
+    return (char*)NULL;
+}
+
+__attribute__((weak)) char* strtok(char* string, const char* separators)
+{
+    static char* savestring = NULL;
+
+    if (string == NULL)
+    {
+        string = savestring;
+        if (string == NULL)
+            return (char*)NULL;
+    }
+
+    char* s1 = string + strspn(string, separators);
+    if (*s1 == '\0')
+    {
+        savestring = NULL;
+        return (char*)NULL;
+    }
+
+    char* s2 = strpbrk(s1, separators);
+    if (s2 != NULL)
+        *s2++ = '\0';
+    savestring = s2;
+    return s1;
+}
+

--- a/mos-platform/common/include/ctype.h
+++ b/mos-platform/common/include/ctype.h
@@ -9,6 +9,8 @@ extern int isprint(int c);
 extern int isdigit(int c);
 extern int isalpha(int c);
 extern int toupper(int c);
+extern int isspace(int c);
+extern int isalnum(int c);
 
 #ifdef __cplusplus
 }

--- a/mos-platform/common/include/string.h
+++ b/mos-platform/common/include/string.h
@@ -25,6 +25,11 @@ int strncmp(const char *s1, const char *s2, size_t n);
 char *strncpy(char * __restrict__ s1, const char * __restrict__ s2, size_t n);
 
 char *strrchr(const char *s, int c);
+char *strrev(char *str);
+size_t strspn(const char* string, const char* in);
+char* strpbrk(const char* string, const char* brk);
+char* strtok(char* string, const char* separators);
+
 
 // Version of memset with better arguments for MOS. All non-pointer arguments
 // can fit in registers, and there is no superfluous return value. Compiler

--- a/mos-platform/cpm65/CMakeLists.txt
+++ b/mos-platform/cpm65/CMakeLists.txt
@@ -29,6 +29,7 @@ add_platform_library(cpm65-c
   putchar.c
   stack.S
   registers.S
+  parsefcb.c
 )
 merge_libraries(cpm65-c
   common-c

--- a/mos-platform/cpm65/cpm-wrappers.c
+++ b/mos-platform/cpm65/cpm-wrappers.c
@@ -15,6 +15,11 @@ void cpm_printstring(const char* s) /* $-terminated */
     cpm_printstring_i((uint16_t)s);
 }
 
+uint8_t cpm_readline(uint8_t* buffer)
+{
+	return cpm_readline_i((uint16_t)buffer);
+}
+
 uint8_t cpm_open_file(FCB* fcb)
 {
     return cpm_open_file_i((uint16_t)fcb);
@@ -118,5 +123,15 @@ void cpm_bios_setdma(void* dma)
 void cpm_bios_setsec(uint32_t* sector)
 {
 	cpm_bios_setsec_i((uint16_t) sector);
+}
+
+void cpm_bios_adddrv(DRIVER* driver)
+{
+	cpm_bios_adddrv_i((uint16_t) driver);
+}
+
+void* cpm_bios_finddrv(uint16_t id)
+{
+	return (void*) cpm_bios_finddrv_i(id);
 }
 

--- a/mos-platform/cpm65/cpm.S
+++ b/mos-platform/cpm65/cpm.S
@@ -41,7 +41,7 @@ cpmentry cpm_conio,                    6
 cpmentry cpm_get_iobyte,               7
 cpmentry cpm_set_iobyte,               8
 cpmentry cpm_printstring_i,            9
-cpmentry cpm_readline,                10, __cpmexiter_errno
+cpmentry cpm_readline_i,              10, __cpmexiter_errno
 cpmentry cpm_const,                   11
 cpmentry cpm_get_version,             12
 cpmentry cpm_reset_disk_system,       13

--- a/mos-platform/cpm65/cpm.h
+++ b/mos-platform/cpm65/cpm.h
@@ -82,6 +82,12 @@ typedef struct __attribute__((packed))
 }
 DPH;
 
+typedef struct {
+    uint16_t id;
+    const char* name;
+    void* strategy;
+} DRIVER;
+
 enum
 {
     CPME_OK        = 0x00, /* success (usually) */
@@ -103,6 +109,11 @@ extern uint8_t cpm_cmdlinelen;
 extern char cpm_cmdline[0x7f];
 extern uint8_t cpm_errno;
 
+/* Parses a filename into the supplied FCB. Returns false if valid, true if
+ * not. */
+
+extern uint8_t cpm_parse_filename(FCB* fcb, const char* filename);
+
 /*  0 */ extern __attribute__((leaf)) void _Noreturn cpm_warmboot(void);
 /*  1 */ extern __attribute__((leaf)) uint8_t cpm_conin(void);
 /*  2 */ extern __attribute__((leaf)) void cpm_conout(uint8_t b);
@@ -114,7 +125,8 @@ extern uint8_t cpm_errno;
 /*  8 */ extern __attribute__((leaf)) void cpm_set_iobyte(uint8_t iob);
 /*  9 */ extern __attribute__((leaf)) void cpm_printstring_i(uint16_t s);
          extern                       void cpm_printstring(const char* s); /* $-terminated */
-/* 10 */ extern __attribute__((leaf)) uint8_t cpm_readline(uint8_t* buffer);
+/* 10 */ extern __attribute__((leaf)) uint8_t cpm_readline_i(uint16_t buffer);
+/*    */ extern                       uint8_t cpm_readline(uint8_t* buffer);
 /* 11 */ extern __attribute__((leaf)) uint8_t cpm_const(void);
 /* 12 */ extern __attribute__((leaf)) uint16_t cpm_get_version(void);
 /* 13 */ extern __attribute__((leaf)) void cpm_reset_disk_system(void);
@@ -181,6 +193,10 @@ extern __attribute__((leaf)) uint16_t cpm_bios_gettpa(void);
 extern __attribute__((leaf)) void cpm_bios_settpa(uint8_t start, uint8_t end);
 extern __attribute__((leaf)) uint16_t cpm_bios_getzp(void);
 extern __attribute__((leaf)) void cpm_bios_setzp(uint8_t start, uint8_t end);
+extern __attribute__((leaf)) void cpm_bios_adddrv_i(uint16_t driver);
+extern                       void cpm_bios_adddrv(DRIVER* driver);
+extern __attribute__((leaf)) uint16_t cpm_bios_finddrv_i(uint16_t id);
+extern                       void* cpm_bios_finddrv(uint16_t id);
 
 #ifdef __cplusplus
 }

--- a/mos-platform/cpm65/link.ld
+++ b/mos-platform/cpm65/link.ld
@@ -46,7 +46,9 @@ SECTIONS {
 		*(.zp.data .zp.data.*)
 		*(.zp.rodata .zp.rodata.*)
 	} >zp AT>ram :init
-	INCLUDE zp-data-symbols.ld
+	__zp_data_load_start = ADDR(.text) + 
+		(LOADADDR(.zp.data) - LOADADDR(.text));
+	__zp_data_size = SIZEOF(.zp.data);
 
 	.pblock (NOLOAD) : {
 		_pblock = .;

--- a/mos-platform/cpm65/parsefcb.c
+++ b/mos-platform/cpm65/parsefcb.c
@@ -1,0 +1,63 @@
+/* Parses an FCB from a filename.
+ *
+ * © 2023 David Given
+ * This file is part of the llvm-mos-sdk project and is redistributable under
+ * the terms of the Apache 2.0 license with the LLVM exceptions. See the LICENSE
+ * file in the project root for the full text.
+ */
+
+#include <stdio.h>
+#include <stdbool.h>
+#include <ctype.h>
+#include <string.h>
+#include <cpm.h>
+
+static const char* fill(uint8_t* dest, const char* src, int len)
+{
+    do
+    {
+        char c = toupper(*src);
+        if (!c || (c == '.'))
+            c = ' ';
+        else if (c == '*')
+            c = '?';
+        else
+            src++;
+        *dest++ = c;
+    }
+    while (--len);
+    return src;
+}
+
+uint8_t cpm_parse_filename(FCB* fcb, const char* filename)
+{
+    memset(fcb, 0, sizeof(FCB));
+    memset(fcb->f, ' ', sizeof(fcb->f));
+
+	if (filename[0] && (filename[1] == ':'))
+    {
+            uint8_t c = filename[0];
+            c = toupper(c);
+            if (!isalpha(c))
+				return true;
+			c -= '@';
+			if ((c < 'A') || (c > 'P'))
+				return true;
+
+                fcb->dr = c;
+
+            filename += 2;
+    }
+
+    /* Read filename part. */
+
+    filename = fill(&fcb->f[0], filename, 8);
+    filename = strchr(filename, '.');
+    if (filename)
+        fill(&fcb->f[8], filename+1, 3);
+
+    if (fcb->dr == 0)
+        fcb->dr = cpm_get_current_drive() + 1;
+	return false;
+}
+

--- a/mos-platform/cpm65/parsefcb.c
+++ b/mos-platform/cpm65/parsefcb.c
@@ -31,8 +31,10 @@ static const char* fill(uint8_t* dest, const char* src, int len)
 
 uint8_t cpm_parse_filename(FCB* fcb, const char* filename)
 {
-    memset(fcb, 0, sizeof(FCB));
-    memset(fcb->f, ' ', sizeof(fcb->f));
+	for (uint8_t i=0; i<sizeof(FCB); i++)
+		((uint8_t*)fcb)[i] = 0;
+	for (uint8_t i=0; i<sizeof(fcb->f); i++)
+		fcb->f[i] = ' ';
 
 	if (filename[0] && (filename[1] == ':'))
     {


### PR DESCRIPTION
This:

- fixes a bug in the CPM65 headers where one function would corrupt the parameters when called
- updated with some new CPM65 functionality
- added a `cpm_parse_filename` helper function (in pure C)
- adds `isalnum` and `isspace` to ctype
- adds `strrev`, `strspn`, `strpbrk` and `strtok` to strings
