### PR TITLE
[RPC8/e] Fix output binary padding.

### DIFF
--- a/mos-platform/rpc8e/link.ld
+++ b/mos-platform/rpc8e/link.ld
@@ -18,6 +18,12 @@ SECTIONS {
     INCLUDE data.ld
     INCLUDE bss.ld
     INCLUDE noinit.ld
+
+    /* RedPower 2 only properly loads binaries aligned up to 128 bytes. */
+    .pad : {
+        FILL(0x00);
+	. = ALIGN(0x80);
+    }
 }
 
 OUTPUT_FORMAT {


### PR DESCRIPTION
RedPower 2, due to a bug, will only properly process binary files aligned up to the nearest 128-byte boundary.

This wasn't spotted in the initial PR, as the tool I used to write binaries to the game world's save data automatically took care of such alignment for me - however, [a different user](https://twitter.com/chaoticCharacte/status/1670145998264360961), utilizing a different file upload approach, ran into this bug.