### PR TITLE
Unify soft stack initialization.

### DIFF
--- a/mos-platform/atari8/init-stack.S
+++ b/mos-platform/atari8/init-stack.S
@@ -2,10 +2,13 @@
 
 .global __do_init_stack
 
-; Initialize soft stack pointer to MEMTOP
+; Initialize soft stack pointer to MEMTOP+1
 .section .init.100,"axR",@progbits
 __do_init_stack:
+  clc
   lda $2e5
+  adc #1
   sta __rc0
   lda $2e6
+  adc #0
   sta __rc1

--- a/mos-platform/c64/link.ld
+++ b/mos-platform/c64/link.ld
@@ -18,7 +18,7 @@ INPUT(unmap-basic.o)
 
 /* With the BASIC ROM unmapped, set initial soft stack address to 
  * right before the I/O mapped $D000-DFFF area. (It grows down.) */
-__stack = 0xCFFF;
+__stack = 0xD000;
 
 OUTPUT_FORMAT {
     /* Tells the C64 LOAD command where to place the file's contents. */

--- a/mos-platform/cx16/link.ld
+++ b/mos-platform/cx16/link.ld
@@ -15,7 +15,7 @@ MEMORY {
 INCLUDE commodore.ld
 
 /* Set initial soft stack address to end of BASIC area. (It grows down.) */
-__stack = 0x9eff;
+__stack = 0x9f00;
 
 OUTPUT_FORMAT {
     /* Tells the LOAD command where to place the file's contents. */

--- a/mos-platform/mega65/link.ld
+++ b/mos-platform/mega65/link.ld
@@ -28,7 +28,7 @@ INCLUDE commodore.ld
 INPUT(unmap-basic.o)
 
 /* Set initial soft stack address to end of BASIC area. (It grows down.) */
-__stack = 0xcfff;
+__stack = 0xd000;
 
 OUTPUT_FORMAT {
     /* Tells the LOAD command where to place the file's contents. */

--- a/mos-platform/nes-mmc1/c-in-prg-ram-0.ld
+++ b/mos-platform/nes-mmc1/c-in-prg-ram-0.ld
@@ -4,4 +4,4 @@ REGION_ALIAS("c_ram", prg_ram_0)
 /* Ensure that PRG-RAM bank 0 is selected before C starts. */
 INPUT(init-prg-ram-0.o)
 
-__stack = 0x7fff;
+__stack = 0x8000;

--- a/mos-platform/nes/c-in-ram.ld
+++ b/mos-platform/nes/c-in-ram.ld
@@ -1,3 +1,3 @@
 /* Place C sections in NES RAM. */
 REGION_ALIAS("c_ram", ram)
-__stack = 0x07ff;
+__stack = 0x0800;

--- a/mos-platform/osi-c1p/link.ld
+++ b/mos-platform/osi-c1p/link.ld
@@ -17,6 +17,6 @@ SECTIONS { INCLUDE c.ld }
 
 /* Set initial soft stack address to end of RAM area. (It grows down.) */
 /* TODO make RAM size configurable */
-__stack = 0x7FFF;
+__stack = 0x8000;
 
 OUTPUT_FORMAT { TRIM(ram) }

--- a/mos-platform/pet/link.ld
+++ b/mos-platform/pet/link.ld
@@ -19,7 +19,7 @@ MEMORY {
 INCLUDE commodore.ld
 
 /* Grow stack downwards from end of RAM */
-__stack = (__ram_size * 1024) - 1;
+__stack = (__ram_size * 1024);
 
 OUTPUT_FORMAT {
     /* Tells the PET LOAD command where to place the file's contents. */

--- a/mos-platform/rpc8e/init-stack.S
+++ b/mos-platform/rpc8e/init-stack.S
@@ -38,8 +38,7 @@ __do_init_stack:
 	pla
 	sta $00,x
 	txa
-	; FIXME: Does the soft stack point to the final writable byte,
-	; or one byte after?
+	inc a
 	inc a
 	sta __rc0
 


### PR DESCRIPTION
The intended value of the soft stack pointer is the byte *after* the top-most (last) writable byte in the stack area. This matches the convention used by targets "dodo" and "sim"; therefore, this commit fixes it for all other targets.