### PR TITLE
[CX16] Use non-contiguous imaginary register convention to prevent ov…

### DIFF
--- a/mos-platform/commodore/commodore.ld
+++ b/mos-platform/commodore/commodore.ld
@@ -8,7 +8,7 @@
 /* Provide imaginary (zero page) registers in the BASIC area. */
 __rc0 = __basic_zp_start;
 INCLUDE imag-regs.ld
-ASSERT(__rc31 == (__rc0 + 0x1F), "Inconsistent zero page map.")
+/* No assertion - cx16 uses a non-contiguous imaginary register block larger than 32 bytes. */
 
 MEMORY { zp : ORIGIN = __rc31 + 1, LENGTH = __basic_zp_end - (__rc31 + 1) }
 

--- a/mos-platform/cx16/CMakeLists.txt
+++ b/mos-platform/cx16/CMakeLists.txt
@@ -5,7 +5,7 @@ if(NOT CMAKE_CROSSCOMPILING)
 endif()
 
 install(FILES _6522.h cx16.h TYPE INCLUDE)
-install(FILES link.ld TYPE LIB)
+install(FILES imag-regs-cx16.ld link.ld TYPE LIB)
 
 add_platform_object_file(cx16-basic-header basic-header.o basic-header.S)
 

--- a/mos-platform/cx16/CMakeLists.txt
+++ b/mos-platform/cx16/CMakeLists.txt
@@ -5,7 +5,7 @@ if(NOT CMAKE_CROSSCOMPILING)
 endif()
 
 install(FILES _6522.h cx16.h TYPE INCLUDE)
-install(FILES imag-regs-cx16.ld link.ld TYPE LIB)
+install(FILES imag-regs.ld link.ld TYPE LIB)
 
 add_platform_object_file(cx16-basic-header basic-header.o basic-header.S)
 

--- a/mos-platform/cx16/clang.cfg
+++ b/mos-platform/cx16/clang.cfg
@@ -1,3 +1,3 @@
--mlto-zp=110
+-mlto-zp=90
 -D__CX16__
 -mcpu=mos65c02

--- a/mos-platform/cx16/clang.cfg
+++ b/mos-platform/cx16/clang.cfg
@@ -1,3 +1,3 @@
 -mlto-zp=90
 -D__CX16__
--mcpu=mos65c02
+-mcpu=mosw65c02

--- a/mos-platform/cx16/imag-regs-cx16.ld
+++ b/mos-platform/cx16/imag-regs-cx16.ld
@@ -1,0 +1,64 @@
+/* Commander X16 imaginary registers.
+ *
+ * Due to the difference between the Commander X16 and llvm-mos's calling
+ * conventions, we try to provide a satisfactory mix of both.
+ *
+ * Commander X16 registers: r0-r15
+ * - caller-saved: r11-r15
+ * - callee-saved: r0-r10
+ *   - arguments: r0-r5
+ *
+ * llvm-mos registers: rs0-rs15
+ * - caller-saved: rs1-rs9
+ * - callee-saved: rs0, rs10-rs15
+ *   - rs15 is expected to be the last register on the zero page in
+ *     commodore.ld.
+ * - symbols refer to bytes: __rc(2N) => __rs(N)
+ *
+ * In addition, this file provides symbols for Commander X16 registers - that
+ * is, __r0 through __r15.
+ */
+
+__r0  = 0x0002;
+__r1  = 0x0004;
+__r2  = 0x0006;
+__r3  = 0x0008;
+__r4  = 0x000a;
+__r5  = 0x000c;
+__r6  = 0x000e;
+__r7  = 0x0010;
+__r8  = 0x0012;
+__r9  = 0x0014;
+__r10 = 0x0016;
+__r11 = 0x0018;
+__r12 = 0x001a;
+__r13 = 0x001c;
+__r14 = 0x001e;
+__r15 = 0x0020;
+
+/* LLVM-MOS caller-saved => X16 callee-saved (arguments; rs1-rs4 => r0-r3).
+ * This allows setting arguments in KERNAL wrappers without stashing.
+ */
+__rc2  = __r0;
+__rc4  = __r1;
+__rc6  = __r2;
+__rc8  = __r3;
+/* X16 r4, r5 is left unallocated. */
+
+/* LLVM-MOS caller-saved => X16 caller-saved (rs5-rs9 => r6-r10). */
+__rc10 = __r6;
+__rc12 = __r7;
+__rc14 = __r8;
+__rc16 = __r9;
+__rc18 = __r10;
+
+/* LLVM-MOS callee-saved => X16 callee-saved (scratch; rs10-rs14 => r11-r15). */
+__rc20 = __r11;
+__rc22 = __r12;
+__rc24 = __r13;
+__rc26 = __r14;
+__rc28 = __r15;
+
+/* Remaining LLVM-MOS imaginary registers (rs0, rs15). */
+__rc0  = 0x0022;
+__rc30 = 0x0024;

--- a/mos-platform/cx16/imag-regs.ld
+++ b/mos-platform/cx16/imag-regs.ld
@@ -62,3 +62,21 @@ __rc28 = __r15;
 /* Remaining LLVM-MOS imaginary registers (rs0, rs15). */
 __rc0  = 0x0022;
 __rc30 = 0x0024;
+
+/* Odd pairs. */
+__rc1 = __rc0 + 1;
+__rc3 = __rc2 + 1;
+__rc5 = __rc4 + 1;
+__rc7 = __rc6 + 1;
+__rc9 = __rc8 + 1;
+__rc11 = __rc10 + 1;
+__rc13 = __rc12 + 1;
+__rc15 = __rc14 + 1;
+__rc17 = __rc16 + 1;
+__rc19 = __rc18 + 1;
+__rc21 = __rc20 + 1;
+__rc23 = __rc22 + 1;
+__rc25 = __rc24 + 1;
+__rc27 = __rc26 + 1;
+__rc29 = __rc28 + 1;
+__rc31 = __rc30 + 1;

--- a/mos-platform/cx16/link.ld
+++ b/mos-platform/cx16/link.ld
@@ -5,8 +5,6 @@
  * Produces a PRG file with a SYS command to start the program.
  */
 
-INCLUDE imag-regs-cx16.ld
-
 __basic_zp_start = 0x0002;
 __basic_zp_end = 0x0080;
 

--- a/mos-platform/cx16/link.ld
+++ b/mos-platform/cx16/link.ld
@@ -5,8 +5,10 @@
  * Produces a PRG file with a SYS command to start the program.
  */
 
+INCLUDE imag-regs-cx16.ld
+
 __basic_zp_start = 0x0002;
-__basic_zp_end = 0x0090;
+__basic_zp_end = 0x0080;
 
 MEMORY {
     ram (rw) : ORIGIN = 0x0801, LENGTH = 0x96ff


### PR DESCRIPTION
…erlap with the X16 KERNAL imaginary registers.

This is a proposed solution for the problem raised in https://github.com/llvm-mos/llvm-mos-sdk/issues/113 . Note, though, that, quoting [the KERNAL specification](https://github.com/X16Community/x16-docs/blob/master/X16%20Reference%20-%2004%20-%20KERNAL.md), "the 16-bit ABI *generally* follows the following conventions". There are a few functions which claim to affect even the so-called "saved" registers, so these will still need stashing - in accordance with the claimed convention.

As a bonus, this PR fixes the size of the zero page user area - `__basic_zp_end` - to match [the specification's memory map](https://github.com/X16Community/x16-docs/blob/master/X16%20Reference%20-%2007%20-%20Memory%20Map.md).

Paging @XarkLabs @bcampbell for their thoughts - I have never worked with the Commander X16 myself.