### PR TITLE
add cbm-K-rdtim commodore kernal call

### DIFF
--- a/mos-platform/commodore/CMakeLists.txt
+++ b/mos-platform/commodore/CMakeLists.txt
@@ -41,6 +41,7 @@ add_platform_library(commodore-c
   cbm_k_listen.c
   cbm_k_load.s
   cbm_k_open.s
+  cbm_k_rdtim.s
   cbm_k_readst.c
   cbm_k_save.s
   cbm_k_scnkey.c

--- a/mos-platform/commodore/cbm.h
+++ b/mos-platform/commodore/cbm.h
@@ -219,7 +219,7 @@ unsigned cbm_k_iobase (void) __attribute__((leaf));
 void cbm_k_listen (unsigned char dev);
 void *cbm_k_load(unsigned char flag, void *startaddr) __attribute__((leaf));
 unsigned char cbm_k_open (void) __attribute__((leaf));
-unsigned long cbm_k_rdtim (void);
+unsigned long cbm_k_rdtim (void) __attribute__((leaf));
 unsigned char cbm_k_readst (void);
 unsigned char cbm_k_save(void *startaddr, void *endaddr_plusone) __attribute__((leaf));
 void cbm_k_scnkey (void);

--- a/mos-platform/commodore/cbm.h
+++ b/mos-platform/commodore/cbm.h
@@ -219,6 +219,7 @@ unsigned cbm_k_iobase (void) __attribute__((leaf));
 void cbm_k_listen (unsigned char dev);
 void *cbm_k_load(unsigned char flag, void *startaddr) __attribute__((leaf));
 unsigned char cbm_k_open (void) __attribute__((leaf));
+unsigned long cbm_k_rdtim (void);
 unsigned char cbm_k_readst (void);
 unsigned char cbm_k_save(void *startaddr, void *endaddr_plusone) __attribute__((leaf));
 void cbm_k_scnkey (void);

--- a/mos-platform/commodore/cbm_k_rdtim.s
+++ b/mos-platform/commodore/cbm_k_rdtim.s
@@ -1,0 +1,14 @@
+.text
+
+;
+; unsigned long cbm_k_rdtim (void);
+;
+.global cbm_k_rdtim
+cbm_k_rdtim:
+	jsr __RDTIM	; returns Y/X/A
+	sta __rc2	; A = H
+	lda #$00
+	sta __rc2+1	; zero high byte
+			; X = M
+	tya		; Y = L
+	rts


### PR DESCRIPTION
Add cbm-K-rdtim kernal call to return 24-bit "jiffy clock".