### PR TITLE
Add C64 include paths to mega65 target

### DIFF
--- a/mos-platform/mega65/clang.cfg
+++ b/mos-platform/mega65/clang.cfg
@@ -1,4 +1,5 @@
 -isystem <CFGDIR>/../mos-platform/c64/include
+-I <CFGDIR>/../mos-platform/c64/asminc
 -mlto-zp=110
 -D__MEGA65__
 -mcpu=mos65ce02

--- a/mos-platform/mega65/clang.cfg
+++ b/mos-platform/mega65/clang.cfg
@@ -1,3 +1,4 @@
+-isystem <CFGDIR>/../mos-platform/c64/include
 -mlto-zp=110
 -D__MEGA65__
 -mcpu=mos65ce02


### PR DESCRIPTION
The c64 headers are useful also on mega65 which for example also has VIC2 and SID chips.