### PR TITLE
MEGA65 use the 45GS02 instead of 65CE02

### DIFF
--- a/mos-platform/mega65/clang.cfg
+++ b/mos-platform/mega65/clang.cfg
@@ -2,4 +2,4 @@
 -I <CFGDIR>/../mos-platform/c64/asminc
 -mlto-zp=110
 -D__MEGA65__
--mcpu=mos65ce02
+-mcpu=mos45gs02


### PR DESCRIPTION
The 45GS02 CPU variant has been added to LLVM-MOS (https://github.com/llvm-mos/llvm-mos/pull/324) and should be used by default on MEGA65.