### PR TITLE
Fix initialization of T2 in eater systick code

### DIFF
--- a/mos-platform/eater/crt0/systick.S
+++ b/mos-platform/eater/crt0/systick.S
@@ -21,6 +21,7 @@ __do_init_systick:
   lda #$a0                      ; Enable T2 interrupts.
   sta VIA_IER
   lda #$00                      ; T2 in one-shot mode.
+  sta VIA_ACR
   lda #mos16lo(T2COUNT)         ; T2 interrupt every 1000 clock ticks.
   sta VIA_T2CL
   lda #mos16hi(T2COUNT)


### PR DESCRIPTION
Fix a bug in the intialization of T2 in the eater backend's systick code.  I was loading 0 into A to store into VIA_ACR but wasn't actually storing it.  It probably "just worked" because the register's value at reset time is 0 anyway, but best to be clean about it.