### PR TITLE
Fix MSVC compile error with pce util

### DIFF
--- a/utils/pce-mkcd/pce-mkcd.cc
+++ b/utils/pce-mkcd/pce-mkcd.cc
@@ -16,6 +16,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <fstream>
+#include <functional>
 #include <ios>
 #include <map>
 #include <memory>


### PR DESCRIPTION
This file used std::function without including the <functional> header and fails to compile on VS2022