### PR TITLE
Fix a few Action 53 bugs

### DIFF
--- a/mos-platform/nes-action53/_prg-rom-banked.ld
+++ b/mos-platform/nes-action53/_prg-rom-banked.ld
@@ -15,10 +15,10 @@ MEMORY {
   prg_rom_0     : ORIGIN = __prg_rom_0_lma,     LENGTH = __prg_rom_size >= 32  ? 0x4000 : 0
   prg_rom_1     : ORIGIN = __prg_rom_1_lma,     LENGTH = __prg_rom_size >= 64  ? 0x4000 : 0
   prg_rom_2     : ORIGIN = __prg_rom_2_lma,     LENGTH = __prg_rom_size >= 64  ? 0x4000 : 0
-  prg_rom_fixed : ORIGIN = __prg_rom_fixed_lma, LENGTH = 0x4000 - 0x30
+  prg_rom_fixed : ORIGIN = __prg_rom_fixed_lma, LENGTH = 0x4000 - 0x32
 
   /* Reset stub for the fixed bank. */
-  reset_stub : ORIGIN = 0x10000 - 0x30, LENGTH = 0x10
+  reset_stub : ORIGIN = 0x10000 - 0x32, LENGTH = 0x12
   /* Skip over the required loader space in $ffd0-$fff9 */
   space_for_supervisor : ORIGIN = 0x10000 - 0x20, LENGTH = 0x1a
   vectors : ORIGIN = 0x10000 - 0x6, LENGTH = 6

--- a/mos-platform/nes-action53/bank.s
+++ b/mos-platform/nes-action53/bank.s
@@ -32,17 +32,18 @@
 A53_REG_SELECT	= $5000
 A53_REG_VALUE	= $8000
 
-.section .nmi,"axR",@progbits
-	jsr bank_nmi
-
-.section .text.bank_nmi,"ax",@progbits
-.globl bank_nmi
-bank_nmi:
+.section .nmi.150,"axR",@progbits
+.globl swap_chr_bank_nmi
+swap_chr_bank_nmi:
 	lda #$00
 	sta A53_REG_SELECT
 	lda _CHR_BANK_NEXT
 	sta _CHR_BANK
 	sta A53_REG_VALUE
+
+.section .nmi.300,"axR",@progbits
+.globl restore_prg_bank_nmi
+restore_prg_bank_nmi:
 	lda #$01
 	sta A53_REG_SELECT
 	lda _PRG_BANK
@@ -51,7 +52,6 @@ bank_nmi:
 	; in case we interrupted a bank switch on the main thread
 	lda _BANK_SHADOW
 	sta A53_REG_SELECT
-	rts
 
 .section .text.get_chr_bank,"ax",@progbits
 .globl __get_chr_bank

--- a/mos-platform/nes-action53/reset.s
+++ b/mos-platform/nes-action53/reset.s
@@ -6,6 +6,8 @@ _reset_stub:
     sta $5000
     lda #$ff
     sta $8000
+    lda #2
+    jsr set_mirroring
     jmp _start
 
 .section .vectors,"ax",@progbits

--- a/mos-platform/nes-mmc1/bank.s
+++ b/mos-platform/nes-mmc1/bank.s
@@ -43,7 +43,7 @@ MMC1_PRG	= $e000
 	sta \addr
 .endmacro
 
-.section .nmi,"axR",@progbits
+.section .nmi.100,"axR",@progbits
 	jsr bank_nmi
 
 .section .text.bank_nmi,"ax",@progbits

--- a/mos-platform/nes/famitone2/famitone2.s
+++ b/mos-platform/nes/famitone2/famitone2.s
@@ -504,7 +504,7 @@ music_pause:
 ; in: none
 ;------------------------------------------------------------------------------
 
-.section .nmi,"axR",@progbits
+.section .nmi.200,"axR",@progbits
 	jsr FamiToneUpdate
 
 .section .text.famitone_update,"ax",@progbits

--- a/mos-platform/nes/neslib/neslib.s
+++ b/mos-platform/nes/neslib/neslib.s
@@ -84,7 +84,7 @@ clearVRAM:
 	sta PPUSCROLL
 	sta PPUSCROLL
 
-.section .nmi,"axR",@progbits
+.section .nmi.050,"axR",@progbits
 	jsr neslib_nmi
 
 .section .text.neslib_nmi,"ax",@progbits


### PR DESCRIPTION
Two bug fixes

* Add explicit NMI ordering for all of the NES target mappers with NMI callbacks. This fixes an issue where the neslib nmi isn't guaranteed to be last (which can cause all sorts of problems when it starts doing VRAM updates during the main gameplay)
* Fixes an issue where banking would not take effect because the PRG bank size wasn't set in the reset routine. The also defaults the mirroring mode to VERTICAL (but its easy enough for users to change)