### PR TITLE
Add C++ struct-of-arrays library and example

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -25,6 +25,8 @@ if(HOSTED)
   install_example(hello-putchar)
   add_executable(init-functions init-functions.cc)
   install_example(init-functions)
+  add_executable(struct-of-arrays struct-of-arrays.cc)
+  install_example(struct-of-arrays)
 endif()
 
 if(PLATFORM MATCHES ^nes-)

--- a/examples/struct-of-arrays.cc
+++ b/examples/struct-of-arrays.cc
@@ -2,12 +2,10 @@
 #include <soa.h>
 #include <string.h>
 
-// This provides an exposition of the C++ struct-of-arrays library, soa.h.
-// This represents an array of types as a multidimensional array of bytes: the
-// outer index is the byte offset within the wrapped type, and the inner index
-// is the array index. That is, all of the first bytes are stored, then all of
-// the second bytes, etc. With some care, this allows using the absolute indexed
-// addressing mode to access any byte of the array without pointer arithmetic.
+// This file provides an exposition of the syntax of the C++ struct-of-arrays
+// library, soa.h. This allows expressing arrays of multi-byte types in such a
+// way that the 6502 absolute indexed addressing mode can be used to access the
+// contents. See the introduction in mos-platform/common/include/soa.h.
 
 void transparent_struct();
 

--- a/examples/struct-of-arrays.cc
+++ b/examples/struct-of-arrays.cc
@@ -1,0 +1,173 @@
+#include <cstdio>
+#include <soa.h>
+#include <string.h>
+
+// This provides an exposition of the C++ struct-of-arrays library, soa.h.
+// This represents an array of types as a multidimensional array of bytes: the
+// outer index is the byte offset within the wrapped type, and the inner index
+// is the array index. That is, all of the first bytes are stored, then all of
+// the second bytes, etc. With some care, this allows using the absolute indexed
+// addressing mode to access any byte of the array without pointer arithmetic.
+
+void transparent_struct();
+
+int main() {
+  // This accepts any non-volatile, no alignment, trivial type with standard
+  // layout (loosely, "plain old data").
+  static soa::Array<char, 10> CharArray;
+
+  // SoA array elements can be assigned to.
+  CharArray[0] = 1;
+
+  // An element is a wrapper type, soa::Ptr<T>, that can implicitly be coerced
+  // to the wrapped type, T.
+  char v = CharArray[0];
+  printf("%d\n", v);
+  printf("%d\n", CharArray[0] + 42);
+
+  // When applicable, mutation operations are defined on the wrapper type in
+  // terms of binary operations. For example, the following:
+  CharArray[0] += 42;
+  // Lowers to CharArray[0] = CharArray[0] + 42
+  printf("%d\n", CharArray[0].get());
+
+  // Using them in contexts where implicit coercion doesn't occur (e.g. printf)
+  // requires .get()
+  printf("%d\n", CharArray[0].get());
+
+  // Arrays can be initialized as per usual; this occurs at compile time.
+  static soa::Array<char, 10> InitializedArray = {1, 2};
+  printf("%d\n", InitializedArray[0].get());
+  printf("%d\n", InitializedArray[1].get());
+
+  // Multi-byte types are stored strided by byte, i.e., the below type has all
+  // 10 of the low bytes followed by all 10 of the high bytes. This is true for
+  // any element type; the bytes are treated totally agnostically of what they
+  // contain.
+  static soa::Array<int, 10> IntArray;
+  // The low byte will be at IntArray+1, and the high byte will be at
+  // IntArray+11.
+  IntArray[1] = 0x1234;
+  printf("%x\n", IntArray[1].get());
+
+  // By default, struct types can be accessed by a copy made through implicit
+  // conversion or the arrow operator. This allows access and assignment as a
+  // whole. The compiler may or may be able to optimize this away, but this
+  // doesn't allow ergonomic mutation of individual fields.
+  struct Struct {
+    char c;
+  };
+  static soa::Array<Struct, 10> StructArray;
+  StructArray[0] = {42};
+  printf("%d\n", StructArray[0].get().c);
+  printf("%d\n", StructArray[0]->c);
+  // Won't compile: StructArray[0].c = 3;
+  // Won't compile: StructArray[0]->c = 3;
+
+  // See below for details on how to make struct types transparent.
+  transparent_struct();
+
+  // Array types are supported. Indices into contained arrays must
+  // be compile-time constants; otherwise, the compiler will instantiate a
+  // temporary array of pointers, one per array element, and index through that.
+  static soa::Array<char[3], 10> CharArrayArray = {{45}};
+  printf("%d\n", CharArrayArray[0][0].get());
+  // At CharArrayArray + 2 * 10 + 1
+  CharArrayArray[1][2] = 46;
+  printf("%d\n", CharArrayArray[1][2].get());
+
+  // Even multi-dimensional arrays work.
+  static soa::Array<char[4][4], 10> CharMDArray;
+  // At CharMDArray + ((2 * 4) + 3) * 10 + 1 (whew!)
+  CharMDArray[1][2][3] = 47;
+  // Note that the first index can still be variable, and this would still use
+  // absolute indexed addressing. E.g., CharMDArray[x][2][3], but not
+  // CharMDArray[2][x][3].
+  printf("%d\n", CharMDArray[1][1][1].get());
+
+  // Both indirection and the arrow operator are supported for pointer elements;
+  // using these on the wrapper type forwards to the wrapped type.
+  static soa::Array<Struct *, 10> PtrArray;
+  Struct s = {48};
+  PtrArray[0] = &s;
+  printf("%d\n", (*PtrArray[0]).c);
+  printf("%d\n", PtrArray[0]->c);
+
+  // For non-pointer types, as previously mentioned, the arrow operator produces
+  // a copy of the wrapped element; this allows calling const methods on the
+  // type. Note that this produces a copy; the this pointer may be different on
+  // each invocation.
+  struct MemberFunctions {
+    const MemberFunctions *whoami() const { return this; }
+    char c() const { return 49; }
+  };
+  static soa::Array<MemberFunctions, 10> MemberFunctionsArray;
+  printf("%p\n", MemberFunctionsArray[0]->whoami());
+  printf("%p\n", MemberFunctionsArray[0]->whoami());
+  printf("%d\n", MemberFunctionsArray[0]->c());
+
+  // Call operators are forwarded to functors.
+  struct Functor {
+    char operator()(char x) const { return x; }
+    char operator()(int x) const { return 2 * x; }
+  };
+  static soa::Array<Functor, 10> FunctorArray;
+  // 5
+  printf("%d\n", FunctorArray[0](static_cast<char>(5)));
+  // 20
+  printf("%d\n", FunctorArray[0](10));
+
+  // Derived types work too, so long as they meet the other criteria.
+  struct DerivedStruct : public MemberFunctions {
+    char d() const { return 50; }
+  };
+  static soa::Array<DerivedStruct, 10> DerivedStructArray;
+  printf("%d\n", DerivedStructArray[0]->c());
+  printf("%d\n", DerivedStructArray[0]->d());
+
+  return 0;
+}
+
+// The header <soa-struct.inc> can be used to provide access to the fields of
+// a struct. This specializes soa::Ptr and provides member access to the
+// fields as derived soa::Ptrs. The semantics of field access and mutation
+// are thus the same as with elements of the array. This must be done at the top
+// level.
+struct TransparentStruct {
+  char c, d;
+};
+#define SOA_STRUCT TransparentStruct
+#define SOA_MEMBERS                                                            \
+  MEMBER(c)                                                                    \
+  MEMBER(d)
+#include <soa-struct.inc>
+// The previous defines are automatically #undef-ed by soa-struct.inc. This
+// must be included once per type, and this must be done before the type is
+// first used in a soa::Ptr.
+
+// Unfortunately, derived structs do not automatically inherit the
+// specialization for their parent.
+struct DerivedTransparentStruct : public TransparentStruct {};
+#define SOA_STRUCT DerivedTransparentStruct
+#define SOA_MEMBERS                                                            \
+  MEMBER(c)                                                                    \
+  MEMBER(d)
+#include <soa-struct.inc>
+
+void transparent_struct() {
+  static soa::Array<TransparentStruct, 10> TransparentStructArray;
+  // Note that these are accessed through the dot operator; the arrow still
+  // makes a copy of the struct, as before. The semantics are identical to array
+  // element access; all of the operators described previously work on struct
+  // members.
+  TransparentStructArray[0].c = 43;
+  TransparentStructArray[0].d = 43;
+  ++TransparentStructArray[0].d;
+  // The members are of type soa::Ptr<char>.
+  printf("%d\n", TransparentStructArray[0].c.get());
+  printf("%d\n", TransparentStructArray[0].d.get());
+
+  static soa::Array<DerivedTransparentStruct, 10> DerivedTransparentStructArray;
+  DerivedTransparentStructArray[0].c = 43;
+  printf("%d\n", DerivedTransparentStructArray[0].c.get());
+}

--- a/mos-platform/common/include/soa-struct.inc
+++ b/mos-platform/common/include/soa-struct.inc
@@ -1,0 +1,64 @@
+// Including this header defines a specialization of soa::Ptr for a structure
+// type that makes the structure members accessible as their own individual
+// soa::Ptr objects. That is, given struct Foo { int a, b; }, soa::Ptr<Foo>
+// would have two public members, a, and b, both of type soa::Ptr<int>.
+//
+// To use this, #define SOA_STRUCT to the struct type, and #define SOA_MEMBERS
+// to a space-separated list of the struct member names, each wrapped with
+// MEMBER(). Then, include the header. These preprocessors macros will be
+// automatically undefined by this header.
+//
+// This header must be used before the first use of soa::Ptr for the struct
+// type.
+//
+// Example:
+//   struct Foo { int a, b; }
+//   #define SOA_STRUCT Foo
+//   #define SOA_MEMBERS \
+//     MEMBER(a)         \
+//     MEMBER(b)
+//   #include <soa-struct.inc>
+//
+//   soa::Array<Foo, 10> a;
+//   a[5].b = 42;
+
+template <>
+class soa::Ptr<const SOA_STRUCT> : public soa::BasePtr<const SOA_STRUCT> {
+public:
+#define MEMBER(NAME) soa::Ptr<const decltype(SOA_STRUCT::NAME)> NAME;
+  SOA_MEMBERS
+#undef MEMBER
+
+  template <uint8_t N>
+  [[clang::always_inline]] constexpr Ptr(const uint8_t ByteArrays[][N],
+                                         uint8_t Idx)
+      : BasePtr(ByteArrays, Idx)
+#define MEMBER(NAME) , NAME(ByteArrays + offsetof(SOA_STRUCT, NAME), Idx)
+            SOA_MEMBERS
+#undef MEMBER
+  {
+  }
+
+  using BasePtr<const SOA_STRUCT>::operator=;
+};
+
+template <> class soa::Ptr<SOA_STRUCT> : public soa::BasePtr<SOA_STRUCT> {
+public:
+#define MEMBER(NAME) soa::Ptr<decltype(SOA_STRUCT::NAME)> NAME;
+  SOA_MEMBERS
+#undef MEMBER
+
+  template <uint8_t N>
+  [[clang::always_inline]] constexpr Ptr(uint8_t ByteArrays[][N], uint8_t Idx)
+      : BasePtr(ByteArrays, Idx)
+#define MEMBER(NAME) , NAME(ByteArrays + offsetof(SOA_STRUCT, NAME), Idx)
+            SOA_MEMBERS
+#undef MEMBER
+  {
+  }
+
+  using BasePtr<SOA_STRUCT>::operator=;
+};
+
+#undef SOA_STRUCT
+#undef SOA_MEMBERS

--- a/mos-platform/common/include/soa.h
+++ b/mos-platform/common/include/soa.h
@@ -1,0 +1,374 @@
+#ifndef _SOA_H
+#define _SOA_H
+
+#include <cstdint>
+#include <initializer_list>
+#include <new>
+#include <type_traits>
+#include <utility>
+
+namespace soa {
+
+/// An array implemented as a struct of arrays.
+///
+/// This data structure is logically similar to a C-style array, but each byte
+/// of the array's element type is represented as a seperate array of bytes. In
+/// other words, if a C array were represented as a multidimimensional array of
+/// bytes, uint8_t Bytes[ArrayIdx][ByteIdx], this data structure is its
+/// transpose, uint8_t Bytes[ByteIdx][ArrayIdx]. This can provide more efficient
+/// addressing on the 6502, since its 8-bit indexed addressing modes preclude
+/// automatic scaling needed to efficiently access traditional C arrays.
+///
+/// Because the representation of the elements is broken apart, only trivial
+/// types with standard layouts are supported (think C-style types).
+///
+/// This class loses its performance benefit, and indeed, may hurt performance,
+/// if accessed through a pointer. All uses of this object should be by
+/// explicitly naming the definition. This tends to imply that the definition
+/// is global, but it may also be used as a local variable in functions that
+/// the compiler can prove do not recurse.
+///
+/// The type parameter must be a trivial type with standard layout. It must have
+/// an alignment requirment of 1 byte, and it must not be volatile.
+template <typename T, uint8_t N> class Array;
+
+/// Pointer to an array element.
+///
+/// This proxy provides access to the contents of a specific array element. If
+/// the type is arithmetic or a pointer, it can be used in numeric expressions
+/// with the full range of operators, including the various assignment
+/// operators. If it is a struct, by default the struct type is opaque. It's
+/// members are not directly accessible, and the struct can only be read or
+/// written as a whole. A specialization can be generated to allow for member
+/// access using the soa-struct.inc header; see that header for details.
+///
+/// Pointers should not be stored more than temporarily, and they should not
+/// be used as arguments to functions. This may cause them to acually take on
+/// their logical representation at runtime (an array of pointers, one per
+/// byte), which is typically worse than using a regular C-style array.
+///
+/// A number of helpers are added to make the type more ergonomic, that is, more
+/// like a reference. First, the type is implicitly convertable to and from the
+/// wrapped type, the wrapped type is also directly assignable to the pointer.
+/// Arithmetic assignment operators are implemented in terms of binary
+/// arithmetic on the wrapped type wherever possible. If the wrapped type is a
+/// pointer, the arrow operator functions on the wrapped type. Otherwise, the
+/// arrow operator provides access to the wrapped type itself. This operates by
+/// making a copy of the value and writing it back if modified, so take care
+/// when using this.
+template <typename T> struct Ptr;
+
+/// Base class for pointer to array elements.
+template <typename T> class BasePtr {
+  static_assert(!std::is_volatile_v<T>, "volatile types are not supported");
+  static_assert(std::is_trivial_v<T>, "non-trivial types are unsupported");
+  static_assert(std::is_standard_layout_v<T>,
+                "non-standard layout types are unsupported");
+  static_assert(std::alignment_of_v<T> == 1, "aligned types are not supported");
+
+protected:
+  // Pointers to array elements are represented as an array of pointers to
+  // each byte. This keeps the representation agnostic of the size of the
+  // original array.
+  const uint8_t *BytePtrs[sizeof(T)];
+
+public:
+  template <uint8_t N>
+  [[clang::always_inline]] constexpr BasePtr(const uint8_t ByteArrays[][N],
+                                             uint8_t Idx) {
+#pragma unroll
+    for (uint8_t ByteIdx = 0; ByteIdx < sizeof(T); ++ByteIdx)
+      BytePtrs[ByteIdx] = &ByteArrays[ByteIdx][Idx];
+  }
+
+  template <uint8_t N>
+  [[clang::always_inline]] constexpr BasePtr(uint8_t ByteArrays[][N],
+                                             uint8_t Idx) {
+#pragma unroll
+    for (uint8_t ByteIdx = 0; ByteIdx < sizeof(T); ++ByteIdx)
+      BytePtrs[ByteIdx] = &ByteArrays[ByteIdx][Idx];
+  }
+
+  /// Return the value of the pointer.
+  ///
+  /// This provides a more readable syntax than casting for contexts where the
+  /// implicit conversion to T doesn't trigger, e.g., in printf.
+  [[clang::always_inline]] T get() const { return static_cast<T>(*this); }
+
+  [[clang::always_inline]] constexpr operator T() const {
+    uint8_t Bytes[sizeof(T)];
+#pragma unroll
+    for (uint8_t Idx = 0; Idx < sizeof(T); ++Idx)
+      Bytes[Idx] = *BytePtrs[Idx];
+    return *reinterpret_cast<const T *>(Bytes);
+  }
+
+  template <typename... ArgsT>
+  [[clang::always_inline]] auto operator()(ArgsT &&...Args) const -> auto {
+    return static_cast<const T>(get())(std::forward<ArgsT>(Args)...);
+  }
+
+  template <typename Q = T>
+  [[clang::always_inline]] std::enable_if_t<!std::is_const_v<Q>, const Ptr<T> &>
+  operator=(const T &Val) {
+    auto *Bytes = reinterpret_cast<const uint8_t *>(&Val);
+#pragma unroll
+    for (uint8_t Idx = 0; Idx < sizeof(T); ++Idx)
+      *const_cast<uint8_t *>(BytePtrs[Idx]) = Bytes[Idx];
+    return *static_cast<Ptr<T> *>(this);
+  }
+
+  template <typename Q = T>
+  [[clang::always_inline]] std::enable_if_t<std::is_pointer_v<Q>, const T>
+  operator->() const {
+    return *this;
+  }
+  template <typename Q = T>
+  [[clang::always_inline]] std::enable_if_t<std::is_pointer_v<Q>, T>
+  operator->() {
+    return *this;
+  }
+
+private:
+  class ConstWrapper {
+    const T V;
+
+  public:
+    [[clang::always_inline]] ConstWrapper(const Ptr<T> &P) : V(P) {}
+    [[clang::always_inline]] const T *operator->() const { return &V; }
+  };
+
+public:
+  template <typename Q = T>
+  [[clang::always_inline]] std::enable_if_t<!std::is_pointer_v<Q>, ConstWrapper>
+  operator->() const {
+    return *static_cast<const Ptr<T> *>(this);
+  }
+
+  template <typename U>
+  [[clang::always_inline]] Ptr<T> &operator+=(const U &Right) {
+    *this = *this + Right;
+    return *static_cast<Ptr<T> *>(this);
+  }
+
+  template <typename U>
+  [[clang::always_inline]] Ptr<T> &operator-=(const U &Right) {
+    *this = *this - Right;
+    return *static_cast<Ptr<T> *>(this);
+  }
+
+  template <typename U>
+  [[clang::always_inline]] Ptr<T> &operator*=(const U &Right) {
+    *this = *this * Right;
+    return *static_cast<Ptr<T> *>(this);
+  }
+
+  template <typename U>
+  [[clang::always_inline]] Ptr<T> &operator/=(const U &Right) {
+    *this = *this / Right;
+    return *static_cast<Ptr<T> *>(this);
+  }
+
+  template <typename U>
+  [[clang::always_inline]] Ptr<T> &operator%=(const U &Right) {
+    *this = *this % Right;
+    return *static_cast<Ptr<T> *>(this);
+  }
+
+  template <typename U>
+  [[clang::always_inline]] Ptr<T> &operator^=(const U &Right) {
+    *this = *this ^ Right;
+    return *static_cast<Ptr<T> *>(this);
+  }
+
+  template <typename U>
+  [[clang::always_inline]] Ptr<T> &operator&=(const U &Right) {
+    *this = *this & Right;
+    return *static_cast<Ptr<T> *>(this);
+  }
+
+  template <typename U>
+  [[clang::always_inline]] Ptr<T> &operator|=(const U &Right) {
+    *this = *this | Right;
+    return *static_cast<Ptr<T> *>(this);
+  }
+
+  template <typename U>
+  [[clang::always_inline]] Ptr<T> &operator<<=(const U &Right) {
+    *this = *this << Right;
+    return *static_cast<Ptr<T> *>(this);
+  }
+
+  template <typename U>
+  [[clang::always_inline]] Ptr<T> &operator>>=(const U &Right) {
+    *this = *this >> Right;
+    return *static_cast<Ptr<T> *>(this);
+  }
+
+  [[clang::always_inline]] Ptr<T> &operator++() {
+    *this += 1;
+    return *static_cast<Ptr<T> *>(this);
+  }
+  [[clang::always_inline]] Ptr<T> &operator--() {
+    *this -= 1;
+    return *static_cast<Ptr<T> *>(this);
+  }
+
+  [[clang::always_inline]] T operator++(int) {
+    T old = *this;
+    ++*this;
+    return *static_cast<Ptr<T> *>(this);
+  }
+
+  [[clang::always_inline]] T operator--(int) {
+    T old = *this;
+    --*this;
+    return *static_cast<Ptr<T> *>(this);
+  }
+};
+
+template <typename T> class Ptr : public BasePtr<T> {
+public:
+  using BasePtr<T>::BasePtr;
+  using BasePtr<T>::operator=;
+};
+
+template <typename T, uint8_t N> class Ptr<T[N]> {
+  static_assert(!std::is_volatile_v<T>, "volatile types are not supported");
+  static_assert(std::is_trivial_v<T>, "non-trivial types are unsupported");
+  static_assert(std::is_standard_layout_v<T>,
+                "non-standard layout types are unsupported");
+  static_assert(std::alignment_of_v<T> == 1, "aligned types are not supported");
+
+  uint8_t PtrStorage[sizeof(Ptr<T>[N])];
+  [[clang::always_inline]] Ptr<T> *ptrs() {
+    return reinterpret_cast<Ptr<T> *>(PtrStorage);
+  }
+
+public:
+  template <uint8_t M>
+  [[clang::always_inline]] constexpr Ptr(const uint8_t ByteArrays[][M],
+                                         uint8_t Idx) {
+#pragma unroll
+    for (uint8_t ArrayIdx = 0; ArrayIdx < N; ++ArrayIdx)
+      new (&ptrs()[ArrayIdx]) Ptr<T>(ByteArrays + ArrayIdx * sizeof(T), Idx);
+  }
+
+  template <uint8_t M>
+  [[clang::always_inline]] constexpr Ptr(uint8_t ByteArrays[][M], uint8_t Idx) {
+#pragma unroll
+    for (uint8_t ArrayIdx = 0; ArrayIdx < N; ++ArrayIdx)
+      new (&ptrs()[ArrayIdx]) Ptr<T>(ByteArrays + ArrayIdx * sizeof(T), Idx);
+  }
+
+  Ptr<const T> operator[](uint8_t Idx) const { return ptrs()[Idx]; }
+  Ptr<T> operator[](uint8_t Idx) { return ptrs()[Idx]; }
+};
+
+template <typename T, uint8_t N> class ArrayConstIterator {
+  friend class Array<T, N>;
+
+protected:
+  const Array<T, N> &A;
+  uint8_t Idx;
+
+  [[clang::always_inline]] ArrayConstIterator(const Array<T, N> &A, uint8_t Idx)
+      : A(A), Idx(Idx) {}
+
+public:
+  [[clang::always_inline]] Ptr<const T> operator*() const { return A[Idx]; }
+
+  [[clang::always_inline]] ArrayConstIterator &operator++() {
+    ++Idx;
+    return *this;
+  }
+
+  bool operator==(const ArrayConstIterator &Other) const {
+    return &A == &Other.A && Idx == Other.Idx;
+  }
+  bool operator!=(const ArrayConstIterator &Other) const {
+    return !(*this == Other);
+  }
+};
+
+template <typename T, uint8_t N>
+class ArrayIterator : public ArrayConstIterator<T, N> {
+  friend class Array<T, N>;
+
+  using ArrayConstIterator<T, N>::A;
+  using ArrayConstIterator<T, N>::Idx;
+
+  [[clang::always_inline]] ArrayIterator(Array<T, N> &A, uint8_t Idx)
+      : ArrayConstIterator<T, N>(A, Idx) {}
+
+public:
+  [[clang::always_inline]] Ptr<T> operator*() const {
+    return const_cast<soa::Array<T, N> &>(A)[Idx];
+  }
+
+  [[clang::always_inline]] ArrayIterator &operator++() {
+    ArrayConstIterator<T, N>::operator++();
+    return *this;
+  }
+};
+
+template <typename T, uint8_t N> class Array {
+  static_assert(!std::is_volatile_v<T>, "volatile types are not supported");
+  static_assert(std::is_trivial_v<T>, "non-trivial types are unsupported");
+  static_assert(std::is_standard_layout_v<T>,
+                "only standard layout types are supported");
+  static_assert(std::alignment_of_v<T> == 1, "aligned types are not supported");
+
+  uint8_t ByteArrays[sizeof(T)][N];
+
+public:
+  // Note: This partially duplicates the logic in Ptr::operator=, but works for
+  // types like multidimensional arrays where assignment isn't defined.
+  [[clang::always_inline]] constexpr Array(std::initializer_list<T> Entries) {
+    uint8_t Idx = 0;
+    for (const T &Entry : Entries) {
+      const auto *Bytes = reinterpret_cast<const uint8_t *>(&Entry);
+#pragma unroll
+      for (uint8_t ByteIdx = 0; ByteIdx < sizeof(T); ++ByteIdx)
+        ByteArrays[ByteIdx][Idx] = Bytes[ByteIdx];
+      ++Idx;
+    }
+  }
+
+  // Arrays cannot be assigned with operator= above, so provide a specific out
+  // to initialize them with nested initializer lists.
+  [[clang::always_inline]] constexpr Array() = default;
+
+  template <uint8_t M>
+  [[clang::always_inline]] constexpr Array(const Array<T, M> &Other) {
+    memcpy(ByteArrays, Other.ByteArrays, sizeof(Other.ByteArrays));
+  }
+
+  [[clang::always_inline]] constexpr Ptr<T> operator[](uint8_t Idx) {
+    return {ByteArrays, Idx};
+  }
+  [[clang::always_inline]] constexpr Ptr<const T>
+  operator[](uint8_t Idx) const {
+    return {ByteArrays, Idx};
+  }
+
+  [[clang::always_inline]] constexpr ArrayConstIterator<T, N> begin() const {
+    return {*this, 0};
+  }
+  [[clang::always_inline]] constexpr ArrayConstIterator<T, N> end() const {
+    return {*this, size()};
+  }
+
+  [[clang::always_inline]] constexpr ArrayIterator<T, N> begin() {
+    return {*this, 0};
+  }
+  [[clang::always_inline]] constexpr ArrayIterator<T, N> end() {
+    return {*this, size()};
+  }
+
+  [[clang::always_inline]] constexpr uint8_t size() const { return N; }
+};
+
+} // namespace soa
+
+#endif // _SOA_H

--- a/mos-platform/common/include/soa.h
+++ b/mos-platform/common/include/soa.h
@@ -14,7 +14,7 @@ namespace soa {
 /// Consider a normal C array, `T array[N]`. If sizeof(T) > 1, then to access
 /// the `k`th byte of the `I`th entry requires evalutating the expression
 /// `array + sizeof(T) * I + k`. Even if `k` and `array` (that is, it's address)
-/// are compile-time constants, evaluating the index still requires a multiply
+/// are constant, evaluating the index still requires a multiply
 /// and 16-bit addition in the worst case.
 ///
 /// You could think of this as the following multidimensional array: `uint8_t
@@ -24,20 +24,20 @@ namespace soa {
 /// Instead, the indices of this array could be swapped: `uint8_t
 /// array[ByteIdx][Idx]`. Then, accessing the `k`th byte of element `I` would
 /// involve the expression `array + N * k + I`. But, very commonly `array` and
-/// `N * k` are compile time constants! This expression can then be computed
+/// `N * k` are constants! This expression can then be computed
 /// implicitly by the absolute indexed addressing mode. This kind of layout is
 /// commonly performed by hand by experienced C and assembly-language 6502
 /// programmers.
 ///
 /// This library organizes its bytes in precisely the way described above, but
 /// with similar syntax to a regular C++ array. To provide a
-/// performance benefit, you must ensure the array's address is at a link-time
-/// constant memory location, and the offsets accessed for each element must
-/// be compile-time constants. That means that no pointers can
-/// be formed into the contents of an array element; this library enforces this.
-/// Also, this class loses its performance benefit, and indeed, may hurt
-/// performance, if accessed through a pointer, since the addressing described
-/// above then intrinsically involves 16-bit pointer arithmetic.
+/// performance benefit you must ensure the array's address is at a link-time
+/// constant memory location. Simlarly, no pointers can
+/// be formed into the contents of an array element, otherwise the offset into
+/// an array element wouldn't be a compile-time constant. Also, this class loses
+/// its performance benefit, and indeed, may hurt performance, if accessed
+/// through a pointer to soa::Array, since the addressing described above then
+/// intrinsically involves 16-bit pointer arithmetic.
 ///
 /// Because the representation of the elements is broken apart, only trivial
 /// types with standard layouts are supported (think C-style types). It must


### PR DESCRIPTION
This adds two new types to the SDK under `soa.h`:
  - `soa::Array<T, s>` is an array of `T` of size `s`, but where the k'th byte of each `T` are stored contiguously.
  - `soa::Ptr<T>` is a pointer to an element of `soa::Array`.

The include-eable `soa-struct.h` specializes `soa::Ptr<T>` for a struct type, including its members as distinct `soa::Ptr<T>` instances that point to the members.

Using this library allows global arrays of structs to be accessed using the absolute indexed addressing mode if it's always known at compile-time what portion of the struct is being accessed. This is generally true if there are no pointers into the array; in that common case, using this library can produce a huge speedup.

See the included example for more details; the library is quite expansive in practice, so the examples walk through what you can and can't do with it.