### PR TITLE
NES: Rework CNROM, UNROM and UNROM-512 to properly handle NMIs.

### DIFF
--- a/mos-platform/nes-cnrom/bank.c
+++ b/mos-platform/nes-cnrom/bank.c
@@ -8,10 +8,37 @@
 
 __attribute__((section(".zp.bss"))) char _BANK_SHADOW;
 
-__attribute__((leaf)) char get_chr_bank(void) {
-  return _BANK_SHADOW;
+__attribute__((leaf)) void set_chr_bank(char value) {
+  asm volatile("" ::: "memory");
+  _BANK_SHADOW = value;
+  asm volatile("" ::: "memory");
+  rom_poke_safe(value);
+  asm volatile("" ::: "memory");
 }
 
-__attribute__((leaf)) void set_chr_bank(char value) {
-  rom_poke_safe(_BANK_SHADOW = value);
+__attribute__((leaf)) void swap_chr_bank(char value) {
+  asm volatile("" ::: "memory");
+  _BANK_SHADOW = value;
+  asm volatile("" ::: "memory");
 }
+
+__attribute__((leaf)) void split_chr_bank(char value) {
+  asm volatile("" ::: "memory");
+  rom_poke_safe(value);
+  asm volatile("" ::: "memory");
+}
+
+/**
+ * Pass _BANK_SHADOW to the physical bank value at the start of NMI. This
+ * prevents an inconsistency if the NMI is fired between _BANK_SHADOW is set
+ * and the ROM being written to. Doing so at the *start* of NMI allows using
+ * banked_call and the same "switch to new; run code; switch back to old"
+ * code pattern inside NMI handlers.
+ *
+ * TODO: Adapt to C when the AXY caller convention is present, allowing the
+ * compiler to optimize unused shadow variables out.
+ */
+asm(".section .nmi.10,\"axR\",@progbits\n"
+	  "lda _BANK_SHADOW\n"
+	  "tay\n"
+	  "sta __rom_poke_table,y\n");

--- a/mos-platform/nes-cnrom/bank.c
+++ b/mos-platform/nes-cnrom/bank.c
@@ -6,26 +6,19 @@
 #include <rompoke.h>
 #include "bank.h"
 
-__attribute__((section(".zp.bss"))) char _BANK_SHADOW;
+__attribute__((section(".zp.bss"))) volatile char _BANK_SHADOW;
 
 __attribute__((leaf)) void set_chr_bank(char value) {
-  asm volatile("" ::: "memory");
   _BANK_SHADOW = value;
-  asm volatile("" ::: "memory");
   rom_poke_safe(value);
-  asm volatile("" ::: "memory");
 }
 
 __attribute__((leaf)) void swap_chr_bank(char value) {
-  asm volatile("" ::: "memory");
   _BANK_SHADOW = value;
-  asm volatile("" ::: "memory");
 }
 
 __attribute__((leaf)) void split_chr_bank(char value) {
-  asm volatile("" ::: "memory");
   rom_poke_safe(value);
-  asm volatile("" ::: "memory");
 }
 
 /**

--- a/mos-platform/nes-cnrom/bank.c
+++ b/mos-platform/nes-cnrom/bank.c
@@ -6,15 +6,15 @@
 #include <rompoke.h>
 #include "bank.h"
 
-__attribute__((section(".zp.bss"))) volatile char _BANK_SHADOW;
+__attribute__((section(".zp.bss"))) volatile char _BANK_NEXT;
 
 __attribute__((leaf)) void set_chr_bank(char value) {
-  _BANK_SHADOW = value;
+  _BANK_NEXT = value;
   rom_poke_safe(value);
 }
 
 __attribute__((leaf)) void swap_chr_bank(char value) {
-  _BANK_SHADOW = value;
+  _BANK_NEXT = value;
 }
 
 __attribute__((leaf)) void split_chr_bank(char value) {
@@ -22,8 +22,8 @@ __attribute__((leaf)) void split_chr_bank(char value) {
 }
 
 /**
- * Pass _BANK_SHADOW to the physical bank value at the start of NMI. This
- * prevents an inconsistency if the NMI is fired between _BANK_SHADOW is set
+ * Pass _BANK_NEXT to the physical bank value at the start of NMI. This
+ * prevents an inconsistency if the NMI is fired between _BANK_NEXT is set
  * and the ROM being written to. Doing so at the *start* of NMI allows using
  * banked_call and the same "switch to new; run code; switch back to old"
  * code pattern inside NMI handlers.
@@ -32,6 +32,6 @@ __attribute__((leaf)) void split_chr_bank(char value) {
  * compiler to optimize unused shadow variables out.
  */
 asm(".section .nmi.10,\"axR\",@progbits\n"
-	  "lda _BANK_SHADOW\n"
+	  "lda _BANK_NEXT\n"
 	  "tay\n"
 	  "sta __rom_poke_table,y\n");

--- a/mos-platform/nes-cnrom/bank.h
+++ b/mos-platform/nes-cnrom/bank.h
@@ -11,18 +11,29 @@ extern "C" {
 #endif
 
 /**
- * @brief Get the current CHR bank.
- * 
- * @return The current CHR bank.
- */
-__attribute__((leaf)) char get_chr_bank(void);
-
-/**
  * @brief Switch to the given CHR bank.
  * 
  * @param bank_id The bank ID to switch to.
  */
 __attribute__((leaf)) void set_chr_bank(char bank_id);
+
+/**
+ * @brief Switch to the given CHR bank at the next NMI.
+ * This function will only work correctly if NMI generation is enabled
+ * (PPUCTRL bit 7).
+ *
+ * @param bank_id The bank ID to switch to.
+ */
+__attribute__((leaf)) void swap_chr_bank(char bank_id);
+
+/**
+ * @brief Switch to the given CHR bank until the next NMI.
+ * This function will only work correctly if NMI generation is enabled
+ * (PPUCTRL bit 7).
+ *
+ * @param bank_id The bank ID to switch to.
+ */
+__attribute__((leaf)) void split_chr_bank(char bank_id);
 
 #ifdef __cplusplus
 }

--- a/mos-platform/nes-unrom-512/CMakeLists.txt
+++ b/mos-platform/nes-unrom-512/CMakeLists.txt
@@ -16,4 +16,5 @@ add_platform_object_file(nes-unrom-512-crt0-o crt0.o ines.s)
 add_platform_object_file(nes-unrom-512-reset-o reset.o reset.s)
 
 add_platform_library(nes-unrom-512-c bank.c bank.s)
+target_include_directories(nes-unrom-512-c SYSTEM BEFORE PUBLIC ../nes/rompoke)
 target_link_libraries(nes-unrom-512-c PRIVATE common-asminc)

--- a/mos-platform/nes-unrom-512/bank.c
+++ b/mos-platform/nes-unrom-512/bank.c
@@ -3,29 +3,74 @@
 // See https://github.com/llvm-mos/llvm-mos-sdk/blob/main/LICENSE for license
 // information.
 
+#include <rompoke.h>
 #include "bank.h"
 
-extern volatile char _BANK;
+/**
+ * @brief Shadow variable for the currently set bank state.
+ */
 __attribute__((section(".zp.bss"))) char _BANK_SHADOW;
+/**
+ * @brief Shadow variable for the CHR/mirroring bank state 
+ * to be set at next NMI.
+ */
+char _CHR_NMI_BANK_SHADOW;
 
 __attribute__((leaf)) inline char get_bank_state(void) {
   return _BANK_SHADOW;
 }
 
 __attribute__((leaf)) inline char set_bank_state(char value) {
+  asm volatile("" ::: "memory");
   char old = _BANK_SHADOW;
-  _BANK = (_BANK_SHADOW = value);
+  _BANK_SHADOW = value;
+  asm volatile("" ::: "memory");
+  rom_poke_safe(value);
+  asm volatile("" ::: "memory");
   return old;
 }
 
-__attribute__((leaf)) inline char get_bank_bits(char mask) {
+__attribute__((leaf)) static inline char get_bank_bits(char mask) {
   return _BANK_SHADOW & mask;
 }
 
-__attribute__((leaf)) inline char set_bank_bits(char mask, char value) {
+__attribute__((leaf)) static inline char set_prg_bank_bits(char mask, char value) {
+  asm volatile("" ::: "memory");
   char old = _BANK_SHADOW;
-  _BANK = (_BANK_SHADOW = (old & (~mask)) | value);
+  char new = (old & (~mask)) | value;
+  _BANK_SHADOW = new;
+  asm volatile("" ::: "memory");
+  rom_poke_safe(new);
+  asm volatile("" ::: "memory");
   return old;
+}
+
+__attribute__((leaf)) static inline void swap_chr_bank_bits(char mask, char value) {
+  asm volatile("" ::: "memory");
+  char old = _CHR_NMI_BANK_SHADOW;
+  _CHR_NMI_BANK_SHADOW = (old & (~mask)) | value;
+  asm volatile("" ::: "memory");
+}
+
+// Both set _BANK_SHADOW and write to ROM without using _CHR_NMI_BANK_SHADOW.
+#define split_chr_bank_bits set_prg_bank_bits
+
+__attribute__((leaf)) static inline void set_chr_bank_bits(char mask, char value) {
+  asm volatile("" ::: "memory");
+
+  // swap
+  char old = _CHR_NMI_BANK_SHADOW;
+  char new_chr = (old & (~mask)) | value;
+  _CHR_NMI_BANK_SHADOW = new_chr;
+  asm volatile("" ::: "memory");
+
+  // split
+  char current_non_chr = _BANK_SHADOW & 0x1F;
+  char new = current_non_chr | new_chr;
+  _BANK_SHADOW = new;
+  asm volatile("" ::: "memory");
+  rom_poke_safe(new);
+  asm volatile("" ::: "memory");
 }
 
 __attribute__((leaf)) char get_prg_bank(void) {
@@ -33,22 +78,62 @@ __attribute__((leaf)) char get_prg_bank(void) {
 }
 
 __attribute__((leaf)) char set_prg_bank(char value) {
-  return set_bank_bits(PRG_BANK_MASK, value);
+  return set_prg_bank_bits(PRG_BANK_MASK, value);
 }
 
 __attribute__((leaf)) inline char get_chr_bank(void) {
   return get_bank_bits(CHR_BANK_MASK) >> CHR_BANK_SHIFT;
 }
 
-__attribute__((leaf)) inline char set_chr_bank(char bank_id) {
-  return set_bank_bits(CHR_BANK_MASK, bank_id << CHR_BANK_SHIFT);
+__attribute__((leaf)) inline void set_chr_bank(char bank_id) {
+  set_chr_bank_bits(CHR_BANK_MASK, bank_id << CHR_BANK_SHIFT);
+}
+
+__attribute__((leaf)) inline void swap_chr_bank(char bank_id) {
+  swap_chr_bank_bits(CHR_BANK_MASK, bank_id << CHR_BANK_SHIFT);
+}
+
+__attribute__((leaf)) inline void split_chr_bank(char bank_id) {
+  split_chr_bank_bits(CHR_BANK_MASK, bank_id << CHR_BANK_SHIFT);
 }
 
 __attribute__((leaf)) inline char get_mirrored_screen(void) {
   return get_bank_bits(MIRROR_SCREEN_MASK) >> MIRROR_SCREEN_SHIFT;
 }
 
-__attribute__((leaf)) inline char set_mirrored_screen(char screen_id) {
-  return set_bank_bits(MIRROR_SCREEN_MASK, screen_id << MIRROR_SCREEN_SHIFT);
+__attribute__((leaf)) inline void set_mirrored_screen(char screen_id) {
+  set_chr_bank_bits(MIRROR_SCREEN_MASK, screen_id << MIRROR_SCREEN_SHIFT);
 }
 
+__attribute__((leaf)) inline void swap_mirrored_screen(char screen_id) {
+  swap_chr_bank_bits(MIRROR_SCREEN_MASK, screen_id << MIRROR_SCREEN_SHIFT);
+}
+
+__attribute__((leaf)) inline void split_mirrored_screen(char screen_id) {
+  split_chr_bank_bits(MIRROR_SCREEN_MASK, screen_id << MIRROR_SCREEN_SHIFT);
+}
+
+/**
+ * Pass _BANK_SHADOW to the physical bank value at the start of NMI. This
+ * prevents an inconsistency if the NMI is fired between _BANK_SHADOW is set
+ * and the ROM being written to. Doing so at the *start* of NMI allows using
+ * banked_call and the same "switch to new; run code; switch back to old"
+ * code pattern inside NMI handlers.
+ *
+ * To handle CHR-ROM, _CHR_NMI_BANK_SHADOW is OR'd with the masked value of
+ * _BANK_SHADOW, then written back to _BANK_SHADOW. This allows handling all
+ * inconsistency options:
+ *
+ * store _CHR_NMI_BANK_SHADOW
+ * <- NMI writes value to _BANK_SHADOW, then to the mapper register
+ * store _BANK_SHADOW
+ * <- NMI writes value to the mapper register
+ * store mapper register
+ */
+asm(".section .nmi.10,\"axR\",@progbits\n"
+    "lda _BANK_SHADOW\n"
+    "and #$1F\n"
+    "ora _CHR_NMI_BANK_SHADOW\n"
+    "sta _BANK_SHADOW\n"
+    "tay\n"
+    "sta __rom_poke_table,y\n");

--- a/mos-platform/nes-unrom-512/bank.c
+++ b/mos-platform/nes-unrom-512/bank.c
@@ -68,10 +68,6 @@ __attribute__((leaf)) char set_prg_bank(char value) {
   return set_prg_bank_bits(PRG_BANK_MASK, value);
 }
 
-__attribute__((leaf)) inline char get_chr_bank(void) {
-  return get_bank_bits(CHR_BANK_MASK) >> CHR_BANK_SHIFT;
-}
-
 __attribute__((leaf)) inline void set_chr_bank(char bank_id) {
   set_chr_bank_bits(CHR_BANK_MASK, bank_id << CHR_BANK_SHIFT);
 }
@@ -82,10 +78,6 @@ __attribute__((leaf)) inline void swap_chr_bank(char bank_id) {
 
 __attribute__((leaf)) inline void split_chr_bank(char bank_id) {
   split_chr_bank_bits(CHR_BANK_MASK, bank_id << CHR_BANK_SHIFT);
-}
-
-__attribute__((leaf)) inline char get_mirrored_screen(void) {
-  return get_bank_bits(MIRROR_SCREEN_MASK) >> MIRROR_SCREEN_SHIFT;
 }
 
 __attribute__((leaf)) inline void set_mirrored_screen(char screen_id) {

--- a/mos-platform/nes-unrom-512/bank.h
+++ b/mos-platform/nes-unrom-512/bank.h
@@ -77,23 +77,6 @@ __attribute__((leaf)) char get_bank_state(void);
 __attribute__((leaf)) char set_bank_state(char value);
 
 /**
- * @brief Get the value of some bits of the bank state.
- *
- * @param mask The mask to get the value by.
- * @return The masked bank value.
- */
-__attribute__((leaf)) char get_bank_bits(char mask);
-
-/**
- * @brief Set the value of some bits of the bank state.
- *
- * @param mask The mask to set the value by.
- * @param value The value to set. Assumed to be masked.
- * @return The complete previous bank state.
- */
-__attribute__((leaf)) char set_bank_bits(char mask, char value);
-
-/**
  * @brief Call a function from the given $8000-$BFFF PRG bank.
  * 
  * @param bank_id The bank ID to use.
@@ -125,12 +108,29 @@ __attribute__((leaf)) char set_prg_bank(char bank_id);
 __attribute__((leaf)) char get_chr_bank(void);
 
 /**
- * @brief Switch to the given CHR bank.
+ * @brief Switch to the given CHR bank immediately.
  *
  * @param bank_id The bank ID to switch to (0-3).
- * @return The previous bank state.
  */
-__attribute__((leaf)) char set_chr_bank(char bank_id);
+__attribute__((leaf)) void set_chr_bank(char bank_id);
+
+/**
+ * @brief Switch to the given CHR bank at the next NMI.
+ * This function will only work correctly if NMI generation is enabled
+ * (PPUCTRL bit 7).
+ *
+ * @param bank_id The bank ID to switch to (0-3).
+ */
+__attribute__((leaf)) void swap_chr_bank(char bank_id);
+
+/**
+ * @brief Switch to the given CHR bank until the next NMI.
+ * This function will only work correctly if NMI generation is enabled
+ * (PPUCTRL bit 7).
+ *
+ * @param bank_id The bank ID to switch to (0-3).
+ */
+__attribute__((leaf)) void split_chr_bank(char bank_id);
 
 /**
  * @brief Get the current mirrored screen.
@@ -141,13 +141,32 @@ __attribute__((leaf)) char set_chr_bank(char bank_id);
 __attribute__((leaf)) char get_mirrored_screen(void);
 
 /**
- * @brief Switch to the given mirrored screen.
+ * @brief Switch to the given mirrored screen immediately.
  * This is only effective under @ref MAPPER_USE_1_SCREEN .
  *
  * @param screen_id The mirrored screen to switch to (0-1).
- * @return The previous bank state.
  */
-__attribute__((leaf)) char set_mirrored_screen(char screen_id);
+__attribute__((leaf)) void set_mirrored_screen(char screen_id);
+
+/**
+ * @brief Switch to the given mirrored screen at the next NMI.
+ * This is only effective under @ref MAPPER_USE_1_SCREEN .
+ * This function will only work correctly if NMI generation is enabled
+ * (PPUCTRL bit 7).
+ *
+ * @param screen_id The mirrored screen to switch to (0-1).
+ */
+__attribute__((leaf)) void swap_mirrored_screen(char screen_id);
+
+/**
+ * @brief Switch to the given mirrored screen until the next NMI.
+ * This is only effective under @ref MAPPER_USE_1_SCREEN .
+ * This function will only work correctly if NMI generation is enabled
+ * (PPUCTRL bit 7).
+ *
+ * @param screen_id The mirrored screen to switch to (0-1).
+ */
+__attribute__((leaf)) void split_mirrored_screen(char screen_id);
 
 #ifdef __cplusplus
 }

--- a/mos-platform/nes-unrom-512/bank.h
+++ b/mos-platform/nes-unrom-512/bank.h
@@ -101,13 +101,6 @@ __attribute__((leaf)) char get_prg_bank(void);
 __attribute__((leaf)) char set_prg_bank(char bank_id);
 
 /**
- * @brief Get the current CHR bank.
- * 
- * @return The current CHR bank (0-3).
- */
-__attribute__((leaf)) char get_chr_bank(void);
-
-/**
  * @brief Switch to the given CHR bank immediately.
  *
  * @param bank_id The bank ID to switch to (0-3).
@@ -131,14 +124,6 @@ __attribute__((leaf)) void swap_chr_bank(char bank_id);
  * @param bank_id The bank ID to switch to (0-3).
  */
 __attribute__((leaf)) void split_chr_bank(char bank_id);
-
-/**
- * @brief Get the current mirrored screen.
- * This is only effective under @ref MAPPER_USE_1_SCREEN .
- * 
- * @return The current mirrored screen (0-1).
- */
-__attribute__((leaf)) char get_mirrored_screen(void);
 
 /**
  * @brief Switch to the given mirrored screen immediately.

--- a/mos-platform/nes-unrom-512/bank.s
+++ b/mos-platform/nes-unrom-512/bank.s
@@ -5,10 +5,6 @@
 
 .include "imag.inc"
 
-.section .text._bank,"ax",@progbits
-.global _BANK
-_BANK: .byte $FF
-
 .zeropage _BANK_SHADOW
 
 .section .text.banked_call,"ax",@progbits
@@ -24,10 +20,11 @@ banked_call:
 	and #$1F
 	sta __rc20 ; __rc20 = previous PRG bank (saved)
 	lda _BANK_SHADOW
-	and #$70
+	and #$E0
 	ora __rc17
-	sta _BANK ; stored: new bank shadow value
 	sta _BANK_SHADOW
+	tay
+	sta __rom_poke_table,y
 
 	; perform indirect call
 	lda __rc2
@@ -38,11 +35,11 @@ banked_call:
 
 	; restore PRG bank
 	lda _BANK_SHADOW
-	and #$70
+	and #$E0
 	ora __rc20
-	sta _BANK ; stored: previous bank shadow value
-	sta _BANK_SHADOW
-
+	tay
 	pla
 	sta __rc20
-	rts
+	tya
+	
+	jmp set_bank_state

--- a/mos-platform/nes-unrom-512/common.ld
+++ b/mos-platform/nes-unrom-512/common.ld
@@ -2,6 +2,9 @@
 
 INCLUDE nes.ld
 
+ASSERT(__prg_rom_size <= 512,
+       "UNROM-512 only supports up to 512 KiB of PRG.")
+
 ASSERT(__chr_rom_size <= 32,
        "UNROM-512 only supports up to 32 KiB of CHR-ROM.")
 ASSERT(__chr_ram_size + __chr_nvram_size <= 32,

--- a/mos-platform/nes-unrom/bank.c
+++ b/mos-platform/nes-unrom/bank.c
@@ -9,18 +9,15 @@
 /**
  * @brief Shadow variable for the currently set bank state.
  */
-__attribute__((section(".zp.bss"))) char _BANK_SHADOW;
+__attribute__((section(".zp.bss"))) volatile char _BANK_SHADOW;
 
 __attribute__((leaf)) char get_prg_bank(void) {
   return _BANK_SHADOW;
 }
 
 __attribute__((leaf)) void set_prg_bank(char value) {
-  asm volatile("" ::: "memory");
   _BANK_SHADOW = value;
-  asm volatile("" ::: "memory");
   rom_poke_safe(value);
-  asm volatile("" ::: "memory");
 }
 
 /**

--- a/mos-platform/nes-unrom/bank.c
+++ b/mos-platform/nes-unrom/bank.c
@@ -6,6 +6,9 @@
 #include <rompoke.h>
 #include "bank.h"
 
+/**
+ * @brief Shadow variable for the currently set bank state.
+ */
 __attribute__((section(".zp.bss"))) char _BANK_SHADOW;
 
 __attribute__((leaf)) char get_prg_bank(void) {
@@ -13,5 +16,24 @@ __attribute__((leaf)) char get_prg_bank(void) {
 }
 
 __attribute__((leaf)) void set_prg_bank(char value) {
-  rom_poke_safe(_BANK_SHADOW = value);
+  asm volatile("" ::: "memory");
+  _BANK_SHADOW = value;
+  asm volatile("" ::: "memory");
+  rom_poke_safe(value);
+  asm volatile("" ::: "memory");
 }
+
+/**
+ * Pass _BANK_SHADOW to the physical bank value at the start of NMI. This
+ * prevents an inconsistency if the NMI is fired between _BANK_SHADOW is set
+ * and the ROM being written to. Doing so at the *start* of NMI allows using
+ * banked_call and the same "switch to new; run code; switch back to old"
+ * code pattern inside NMI handlers.
+ *
+ * TODO: Adapt to C when the AXY caller convention is present, allowing the
+ * compiler to optimize unused shadow variables out.
+ */
+asm(".section .nmi.10,\"axR\",@progbits\n"
+	  "lda _BANK_SHADOW\n"
+	  "tay\n"
+	  "sta __rom_poke_table,y\n");

--- a/mos-platform/nes-unrom/common.ld
+++ b/mos-platform/nes-unrom/common.ld
@@ -2,6 +2,9 @@
 
 INCLUDE nes.ld
 
+ASSERT(__prg_rom_size <= 4096,
+       "UNROM only supports up to 4096 KiB of PRG.")
+
 ASSERT(__chr_rom_size <= 8, "UNROM only supports up to 8 KiB of CHR-ROM.")
 ASSERT(__chr_ram_size + __chr_nvram_size <= 8,
        "UNROM only supports up to 8KiB of CHR-(NV)RAM.")

--- a/test/nes-cnrom/CMakeLists.txt
+++ b/test/nes-cnrom/CMakeLists.txt
@@ -1,11 +1,12 @@
 cmake_minimum_required(VERSION 3.18)
 
-project(test-nes-mmc1 LANGUAGES C)
+project(test-nes-cnrom LANGUAGES C)
 
 include(../test.cmake)
 
 add_mesen_test(minimal)
 add_mesen_test(chr-ram)
 add_mesen_test(chr-rom)
+add_mesen_test(chr-swap-split)
 
 add_subdirectory(no-compile)

--- a/test/nes-cnrom/chr-swap-split.c
+++ b/test/nes-cnrom/chr-swap-split.c
@@ -1,0 +1,72 @@
+#include <nes.h>
+#include <bank.h>
+#include <peekpoke.h>
+#include <stdlib.h>
+
+asm(".globl __chr_ram_size\n"
+    "__chr_ram_size = 0\n"
+    ".globl __chr_rom_size\n"
+    "__chr_rom_size = 32\n");
+
+__attribute__((used, section(".chr_rom_0")))
+const char cr0[8192] = {1, [8191] = 2};
+__attribute__((used, section(".chr_rom_3")))
+const char cr3[8192] = {3, [8191] = 4};
+
+void ppu_wait_vblank(void) {
+  while (!(PPU.status & 0x80))
+    ;
+}
+
+char read_ppu(unsigned ppu_addr) {
+  (void)PPU.status;
+  PPU.vram.address = (unsigned)ppu_addr >> 8;
+  PPU.vram.address = (unsigned)ppu_addr;
+  (void)PPU.vram.data;
+  return PPU.vram.data;
+}
+
+int main(void) {
+  // Enable NMI generation.
+  PPU.control = 0x80;
+  
+  ppu_wait_vblank();
+
+  // set changes immediately
+  set_chr_bank(0);
+  if (read_ppu(0) != 1)
+    return EXIT_FAILURE;
+  if (read_ppu(8191) != 2)
+    return EXIT_FAILURE;
+  ppu_wait_vblank();
+  if (read_ppu(0) != 1)
+    return EXIT_FAILURE;
+  if (read_ppu(8191) != 2)
+    return EXIT_FAILURE;
+
+  // split changes until NMI (vblank)
+  split_chr_bank(3);
+  if (read_ppu(0) != 3)
+    return EXIT_FAILURE;
+  if (read_ppu(8191) != 4)
+    return EXIT_FAILURE;
+  ppu_wait_vblank();
+  if (read_ppu(0) != 1)
+    return EXIT_FAILURE;
+  if (read_ppu(8191) != 2)
+    return EXIT_FAILURE;
+
+  // swap changes after NMI (vblank)
+  swap_chr_bank(3);
+  if (read_ppu(0) != 1)
+    return EXIT_FAILURE;
+  if (read_ppu(8191) != 2)
+    return EXIT_FAILURE;
+  ppu_wait_vblank();
+  if (read_ppu(0) != 3)
+    return EXIT_FAILURE;
+  if (read_ppu(8191) != 4)
+    return EXIT_FAILURE;
+
+  return EXIT_SUCCESS;
+}

--- a/test/nes-unrom-512/CMakeLists.txt
+++ b/test/nes-unrom-512/CMakeLists.txt
@@ -9,5 +9,6 @@ add_mesen_test(prg-rom-512)
 add_mesen_test(prg-rom-banked-call)
 add_mesen_test(chr-ram)
 add_mesen_test(chr-rom)
+add_mesen_test(chr-swap-split)
 
 add_subdirectory(no-compile)

--- a/test/nes-unrom-512/chr-swap-split.c
+++ b/test/nes-unrom-512/chr-swap-split.c
@@ -1,0 +1,72 @@
+#include <nes.h>
+#include <bank.h>
+#include <peekpoke.h>
+#include <stdlib.h>
+
+asm(".globl __chr_ram_size\n"
+    "__chr_ram_size = 0\n"
+    ".globl __chr_rom_size\n"
+    "__chr_rom_size = 32\n");
+
+__attribute__((used, section(".chr_rom_0")))
+const char cr0[8192] = {1, [8191] = 2};
+__attribute__((used, section(".chr_rom_3")))
+const char cr3[8192] = {3, [8191] = 4};
+
+void ppu_wait_vblank(void) {
+  while (!(PPU.status & 0x80))
+    ;
+}
+
+char read_ppu(unsigned ppu_addr) {
+  (void)PPU.status;
+  PPU.vram.address = (unsigned)ppu_addr >> 8;
+  PPU.vram.address = (unsigned)ppu_addr;
+  (void)PPU.vram.data;
+  return PPU.vram.data;
+}
+
+int main(void) {
+  // Enable NMI generation.
+  PPU.control = 0x80;
+  
+  ppu_wait_vblank();
+
+  // set changes immediately
+  set_chr_bank(0);
+  if (read_ppu(0) != 1)
+    return EXIT_FAILURE;
+  if (read_ppu(8191) != 2)
+    return EXIT_FAILURE;
+  ppu_wait_vblank();
+  if (read_ppu(0) != 1)
+    return EXIT_FAILURE;
+  if (read_ppu(8191) != 2)
+    return EXIT_FAILURE;
+
+  // split changes until NMI (vblank)
+  split_chr_bank(3);
+  if (read_ppu(0) != 3)
+    return EXIT_FAILURE;
+  if (read_ppu(8191) != 4)
+    return EXIT_FAILURE;
+  ppu_wait_vblank();
+  if (read_ppu(0) != 1)
+    return EXIT_FAILURE;
+  if (read_ppu(8191) != 2)
+    return EXIT_FAILURE;
+
+  // swap changes after NMI (vblank)
+  swap_chr_bank(3);
+  if (read_ppu(0) != 1)
+    return EXIT_FAILURE;
+  if (read_ppu(8191) != 2)
+    return EXIT_FAILURE;
+  ppu_wait_vblank();
+  if (read_ppu(0) != 3)
+    return EXIT_FAILURE;
+  if (read_ppu(8191) != 4)
+    return EXIT_FAILURE;
+
+  return EXIT_SUCCESS;
+}

--- a/test/nes-unrom-512/no-compile/CMakeLists.txt
+++ b/test/nes-unrom-512/no-compile/CMakeLists.txt
@@ -1,3 +1,5 @@
 set_directory_properties(PROPERTIES EXCLUDE_FROM_ALL ON)
 
 add_no_compile_test(chr-ram-too-small-4screen)
+add_no_compile_test(chr-rom-too-big)
+add_no_compile_test(prg-rom-too-big)

--- a/test/nes-unrom-512/no-compile/chr-rom-too-big.c
+++ b/test/nes-unrom-512/no-compile/chr-rom-too-big.c
@@ -1,0 +1,2 @@
+asm(".globl __chr_rom_size\n__chr_rom_size=64");
+int main(void) { return 0; }

--- a/test/nes-unrom-512/no-compile/prg-rom-too-big.c
+++ b/test/nes-unrom-512/no-compile/prg-rom-too-big.c
@@ -1,0 +1,2 @@
+asm(".globl __prg_rom_size\n__prg_rom_size=1024\n");
+int main(void) { return 0; }


### PR DESCRIPTION
Fixes https://github.com/llvm-mos/llvm-mos-sdk/issues/195 for these three mappers. I *think* this leaves only MMC3 as the remaining mapper without NMI handling (MMC1 and Action53 already had their own; NROM does not require it).

I've implemented my own approach to handling NMIs:

* _BANK_SHADOW is always written to before the mapper's MMIO register itself;
* _BANK_SHADOW is written to MMIO at an early stage of NMI, allowing developer-side consistency for NMI code written in C once the AXY calling convention is added.

For CNROM and UNROM-512, I've extended this with additional functionality:

* The graphical part of the register (CHR bank, mirroring) is now deliberately separated between "shadow" (written to the MMIO register on NMI or on user request) and the MMIO register.
* Writing to the "shadow" without writing to the MMIO register is called a "swap" - this will only apply the result on the next frame. This allows preparing a CHR bank change without affecting the currently drawn frame.
* Writing to the MMIO register without writing to the "shadow" is called a "split" - this will only apply the result *until* the next frame. This allows doing consistent mid-frame effects.

As this may not be immediately intuitive to someone tinkering with the code in the future, I have added a test for these two mappers which automatically validates it.

This required removing `get_chr_bank` on CNROM - well, it didn't *strictly* require it, but then it would require two RAM bytes instead of one; I expect the functionality to be sufficiently unnecessary as to not be worth the added cost. Likewise, the public API of UNROM-512 has changed; as neither API has yet shipped in a production build of the SDK, this is currently not a breaking change.