### PR TITLE
atari8-common: Fix clang.cfg available zero page size

### DIFF
--- a/mos-platform/atari8-common/clang.cfg
+++ b/mos-platform/atari8-common/clang.cfg
@@ -1,2 +1,2 @@
--mlto-zp=206
+-mlto-zp=96
 -D__ATARI__


### PR DESCRIPTION
Per `link.ld`, the Atari 8-bit computers' available zero page encompasses the area of `0x80` to `0xFF`, which is 128 bytes - subtracting the 32 bytes for registers, that's 96 bytes, not 206 bytes.