### PR TITLE
nes: Add ines.h header for general mapper configuration.

### DIFF
--- a/mos-platform/nes-action53/CMakeLists.txt
+++ b/mos-platform/nes-action53/CMakeLists.txt
@@ -15,4 +15,5 @@ add_platform_object_file(nes-action53-crt0-o crt0.o ines.s)
 add_platform_object_file(nes-action53-reset-o reset.o reset.s)
 
 add_platform_library(nes-action53-c bank.c bank.s)
+target_include_directories(nes-action53-c PRIVATE ../nes)
 target_link_libraries(nes-action53-c PRIVATE common-asminc)

--- a/mos-platform/nes-action53/bank.h
+++ b/mos-platform/nes-action53/bank.h
@@ -27,6 +27,8 @@
 #ifndef _BANK_H_
 #define _BANK_H_
 
+#include <ines.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/mos-platform/nes-cnrom/CMakeLists.txt
+++ b/mos-platform/nes-cnrom/CMakeLists.txt
@@ -14,5 +14,6 @@ install(FILES bank.h TYPE INCLUDE)
 add_platform_object_file(nes-cnrom-crt0-o crt0.o ines.s)
 
 add_platform_library(nes-cnrom-c bank.c)
+target_include_directories(nes-cnrom-c PRIVATE ../nes)
 target_include_directories(nes-cnrom-c SYSTEM BEFORE PUBLIC ../nes/rompoke)
 target_link_libraries(nes-cnrom-c PRIVATE common-asminc)

--- a/mos-platform/nes-cnrom/bank.h
+++ b/mos-platform/nes-cnrom/bank.h
@@ -6,6 +6,8 @@
 #ifndef _BANK_H_
 #define _BANK_H_
 
+#include <ines.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/mos-platform/nes-mmc1/CMakeLists.txt
+++ b/mos-platform/nes-mmc1/CMakeLists.txt
@@ -17,4 +17,5 @@ add_platform_object_file(nes-mmc1-init-prg-ram-0-o
   init-prg-ram-0.o init-prg-ram-0.s)
 
 add_platform_library(nes-mmc1-c bank.c bank.s)
+target_include_directories(nes-mmc1-c PRIVATE ../nes)
 target_link_libraries(nes-mmc1-c PRIVATE common-asminc)

--- a/mos-platform/nes-mmc1/bank.h
+++ b/mos-platform/nes-mmc1/bank.h
@@ -27,6 +27,8 @@
 #ifndef _BANK_H_
 #define _BANK_H_
 
+#include <ines.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/mos-platform/nes-mmc3/bank.h
+++ b/mos-platform/nes-mmc3/bank.h
@@ -27,6 +27,8 @@
 #ifndef _BANK_H_
 #define _BANK_H_
 
+#include <ines.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/mos-platform/nes-unrom-512/CMakeLists.txt
+++ b/mos-platform/nes-unrom-512/CMakeLists.txt
@@ -16,5 +16,6 @@ add_platform_object_file(nes-unrom-512-crt0-o crt0.o ines.s)
 add_platform_object_file(nes-unrom-512-reset-o reset.o reset.s)
 
 add_platform_library(nes-unrom-512-c bank.c bank.s)
-target_include_directories(nes-unrom-512-c SYSTEM BEFORE PUBLIC ../nes/rompoke)
+target_include_directories(nes-unrom-512-c PRIVATE ../nes)
+target_include_directories(nes-unrom-512-c PRIVATE ../nes/rompoke)
 target_link_libraries(nes-unrom-512-c PRIVATE common-asminc)

--- a/mos-platform/nes-unrom-512/bank.h
+++ b/mos-platform/nes-unrom-512/bank.h
@@ -6,21 +6,11 @@
 #ifndef _BANK_H_
 #define _BANK_H_
 
+#include <ines.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-/**
- * @brief Define this in a .c file to use 2-screen horizontal mirroring.
- */
-#define MAPPER_USE_2_SCREEN_HORIZONTAL \
-	asm(".globl __mirroring\n.globl __four_screen\n__mirroring = 0\n__four_screen = 0\n")
-
-/**
- * @brief Define this in a .c file to use 2-screen vertical mirroring.
- */
-#define MAPPER_USE_2_SCREEN_VERTICAL \
-	asm(".globl __mirroring\n.globl __four_screen\n__mirroring = 1\n__four_screen = 0\n")
 
 /**
  * @brief Define this in a .c file to use 1-screen switchable mirroring.

--- a/mos-platform/nes-unrom/CMakeLists.txt
+++ b/mos-platform/nes-unrom/CMakeLists.txt
@@ -16,5 +16,6 @@ add_platform_object_file(nes-unrom-crt0-o crt0.o ines.s)
 add_platform_object_file(nes-unrom-reset-o reset.o reset.s)
 
 add_platform_library(nes-unrom-c bank.c bank.s)
-target_include_directories(nes-unrom-c SYSTEM BEFORE PUBLIC ../nes/rompoke)
+target_include_directories(nes-unrom-c PRIVATE ../nes)
+target_include_directories(nes-unrom-c PRIVATE ../nes/rompoke)
 target_link_libraries(nes-unrom-c PRIVATE common-asminc)

--- a/mos-platform/nes-unrom/bank.h
+++ b/mos-platform/nes-unrom/bank.h
@@ -6,6 +6,8 @@
 #ifndef _BANK_H_
 #define _BANK_H_
 
+#include <ines.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/mos-platform/nes/CMakeLists.txt
+++ b/mos-platform/nes/CMakeLists.txt
@@ -5,6 +5,7 @@ if(NOT CMAKE_CROSSCOMPILING)
 endif()
 
 install(FILES
+  ines.h
   nes.h
 TYPE INCLUDE)
 install(FILES

--- a/mos-platform/nes/ines.h
+++ b/mos-platform/nes/ines.h
@@ -1,0 +1,49 @@
+// Copyright 2023 LLVM-MOS Project
+// Licensed under the Apache License, Version 2.0 with LLVM Exceptions.
+// See https://github.com/llvm-mos/llvm-mos-sdk/blob/main/LICENSE for license
+// information.
+
+#ifndef _INES_H_
+#define _INES_H_
+
+// INES header configuration macros
+//
+// Define any of these in one .c/.cpp file to configure the project's INES
+// header. Additional defines are provided on some subtargets via <bank.h>.
+
+#define MAPPER_PRG_ROM_KB(kb) \
+    asm(".globl __prg_rom_size\n__prg_rom_size = " #kb)
+#define MAPPER_PRG_RAM_KB(kb) \
+    asm(".globl __prg_ram_size\n__prg_ram_size = " #kb)
+#define MAPPER_PRG_NVRAM_KB(kb) \
+    asm(".globl __prg_nvram_size\n__prg_nvram_size = " #kb)
+#define MAPPER_CHR_ROM_KB(kb) \
+    asm(".globl __chr_rom_size\n__chr_rom_size = " #kb)
+#define MAPPER_CHR_RAM_KB(kb) \
+    asm(".globl __chr_ram_size\n__chr_ram_size = " #kb)
+#define MAPPER_CHR_NVRAM_KB(kb) \
+    asm(".globl __chr_nvram_size\n__chr_nvram_size = " #kb)
+
+#define MAPPER_USE_HORIZONTAL_MIRRORING \
+	asm(".globl __mirroring\n__mirroring = 0")
+
+#define MAPPER_USE_VERTICAL_MIRRORING \
+	asm(".globl __mirroring\n__mirroring = 1")
+
+#define MAPPER_USE_BATTERY \
+	asm(".globl __battery\n__battery = 1")
+
+#define INES_TIMING(id) \
+    asm(".globl __timing\__timing = " #id)
+#define INES_TIMING_RP2C02 \
+    asm(".globl __timing\n__timing = 0")
+#define INES_TIMING_RP2C07 \
+    asm(".globl __timing\n__timing = 1")
+#define INES_TIMING_MULTIREGION \
+    asm(".globl __timing\n__timing = 2")
+#define INES_TIMING_UA6538 \
+    asm(".globl __timing\n__timing = 3")
+#define INES_DEFAULT_EXPANSION(id) \
+    asm(".globl __default_expansion_device\__default_expansion_device = " #id)
+
+#endif // _INES_H_

--- a/mos-platform/nes/ines.h
+++ b/mos-platform/nes/ines.h
@@ -34,7 +34,7 @@
 	asm(".globl __battery\n__battery = 1")
 
 #define INES_TIMING(id) \
-    asm(".globl __timing\__timing = " #id)
+    asm(".globl __timing\n__timing = " #id)
 #define INES_TIMING_RP2C02 \
     asm(".globl __timing\n__timing = 0")
 #define INES_TIMING_RP2C07 \
@@ -44,6 +44,6 @@
 #define INES_TIMING_UA6538 \
     asm(".globl __timing\n__timing = 3")
 #define INES_DEFAULT_EXPANSION(id) \
-    asm(".globl __default_expansion_device\__default_expansion_device = " #id)
+    asm(".globl __default_expansion_device\n__default_expansion_device = " #id)
 
 #endif // _INES_H_

--- a/test/nes-cnrom/chr-ram.c
+++ b/test/nes-cnrom/chr-ram.c
@@ -3,10 +3,8 @@
 #include <peekpoke.h>
 #include <stdlib.h>
 
-asm(".globl __chr_rom_size\n"
-    "__chr_rom_size = 0\n"
-    ".globl __chr_ram_size\n"
-    "__chr_ram_size = 512\n");
+MAPPER_CHR_ROM_KB(0);
+MAPPER_CHR_RAM_KB(512);
 
 void poke_ppu(unsigned addr, char val) {
   PPU.vram.address = addr >> 8;

--- a/test/nes-cnrom/chr-rom.c
+++ b/test/nes-cnrom/chr-rom.c
@@ -3,8 +3,8 @@
 #include <peekpoke.h>
 #include <stdlib.h>
 
-asm(".globl __chr_rom_size\n"
-    "__chr_rom_size = 2048\n");
+MAPPER_CHR_ROM_KB(2048);
+MAPPER_CHR_RAM_KB(0);
 
 __attribute__((used, section(".chr_rom_0")))
 const char cr0[8192] = {1, [8191] = 2};

--- a/test/nes-cnrom/chr-swap-split.c
+++ b/test/nes-cnrom/chr-swap-split.c
@@ -3,10 +3,8 @@
 #include <peekpoke.h>
 #include <stdlib.h>
 
-asm(".globl __chr_ram_size\n"
-    "__chr_ram_size = 0\n"
-    ".globl __chr_rom_size\n"
-    "__chr_rom_size = 32\n");
+MAPPER_CHR_ROM_KB(32);
+MAPPER_CHR_RAM_KB(0);
 
 __attribute__((used, section(".chr_rom_0")))
 const char cr0[8192] = {1, [8191] = 2};

--- a/test/nes-cnrom/no-compile/chr-rom-too-big.c
+++ b/test/nes-cnrom/no-compile/chr-rom-too-big.c
@@ -1,2 +1,3 @@
-asm(".globl __chr_rom_size\n__chr_rom_size=4096");
+#include <bank.h>
+MAPPER_CHR_ROM_KB(4096);
 int main(void) { return 0; }

--- a/test/nes-mmc1/chr-ram.c
+++ b/test/nes-mmc1/chr-ram.c
@@ -3,10 +3,8 @@
 #include <peekpoke.h>
 #include <stdlib.h>
 
-asm(".globl __chr_rom_size\n"
-    "__chr_rom_size = 0\n"
-    ".globl __chr_ram_size\n"
-    "__chr_ram_size = 8\n");
+MAPPER_CHR_ROM_KB(0);
+MAPPER_CHR_RAM_KB(8);
 
 void set_8k_banks(void) { set_mmc1_ctrl(0b01100); }
 

--- a/test/nes-mmc1/no-compile/chr-nvram-uneven-banks.c
+++ b/test/nes-mmc1/no-compile/chr-nvram-uneven-banks.c
@@ -1,2 +1,3 @@
-asm(".globl __chr_nvram_size\n__chr_nvram_size=2\n");
+#include <bank.h>
+MAPPER_CHR_NVRAM_KB(2);
 int main(void) { return 0; }

--- a/test/nes-mmc1/no-compile/chr-ram-too-big.c
+++ b/test/nes-mmc1/no-compile/chr-ram-too-big.c
@@ -1,3 +1,4 @@
-asm(".globl __chr_ram_size\n__chr_ram_size=8\n");
-asm(".globl __chr_nvram_size\n__chr_nvram_size=8\n");
+#include <bank.h>
+MAPPER_CHR_RAM_KB(8);
+MAPPER_CHR_NVRAM_KB(8);
 int main(void) { return 0; }

--- a/test/nes-mmc1/no-compile/chr-ram-uneven-banks.c
+++ b/test/nes-mmc1/no-compile/chr-ram-uneven-banks.c
@@ -1,2 +1,3 @@
-asm(".globl __chr_ram_size\n__chr_ram_size=2\n");
+#include <bank.h>
+MAPPER_CHR_RAM_KB(2);
 int main(void) { return 0; }

--- a/test/nes-mmc1/no-compile/chr-rom-too-big.c
+++ b/test/nes-mmc1/no-compile/chr-rom-too-big.c
@@ -1,2 +1,3 @@
-asm(".globl __chr_rom_size\n__chr_rom_size=256");
+#include <bank.h>
+MAPPER_CHR_ROM_KB(256);
 int main(void) { return 0; }

--- a/test/nes-mmc1/no-compile/prg-nvram-uneven-banks.c
+++ b/test/nes-mmc1/no-compile/prg-nvram-uneven-banks.c
@@ -1,2 +1,3 @@
-asm(".globl __prg_nvram_size\n__prg_nvram_size=2");
+#include <bank.h>
+MAPPER_PRG_NVRAM_KB(2);
 int main(void) { return 0; }

--- a/test/nes-mmc1/no-compile/prg-ram-too-big.c
+++ b/test/nes-mmc1/no-compile/prg-ram-too-big.c
@@ -1,3 +1,4 @@
-asm(".globl __prg_ram_size\n__prg_ram_size=32\n"
-    ".globl __prg_nvram_size\n__prg_nvram_size=32\n");
+#include <bank.h>
+MAPPER_PRG_RAM_KB(32);
+MAPPER_PRG_NVRAM_KB(32);
 int main(void) { return 0; }

--- a/test/nes-mmc1/no-compile/prg-ram-uneven-banks.c
+++ b/test/nes-mmc1/no-compile/prg-ram-uneven-banks.c
@@ -1,2 +1,3 @@
-asm(".globl __prg_ram_size\n__prg_ram_size=2");
+#include <bank.h>
+MAPPER_PRG_RAM_KB(2);
 int main(void) { return 0; }

--- a/test/nes-mmc1/prg-ram-c.c
+++ b/test/nes-mmc1/prg-ram-c.c
@@ -1,7 +1,8 @@
+#include <bank.h>
 #include <peekpoke.h>
 #include <stdlib.h>
 
-asm(".global __prg_ram_size\n__prg_ram_size=32\n");
+MAPPER_PRG_RAM_KB(32);
 
 volatile char c[8100] = {1, [8099] = 2};
 

--- a/test/nes-mmc1/prg-ram.c
+++ b/test/nes-mmc1/prg-ram.c
@@ -2,8 +2,8 @@
 #include <peekpoke.h>
 #include <stdlib.h>
 
-asm(".global __prg_ram_size\n__prg_ram_size=32\n");
-asm(".global __prg_rom_size\n__prg_rom_size=128\n");
+MAPPER_PRG_RAM_KB(32);
+MAPPER_PRG_ROM_KB(128);
 
 __attribute__((section(".prg_ram_0.noinit"))) volatile char c[8192];
 

--- a/test/nes-mmc1/prg-rom-128.c
+++ b/test/nes-mmc1/prg-rom-128.c
@@ -2,7 +2,7 @@
 #include <peekpoke.h>
 #include <stdlib.h>
 
-asm(".global __prg_rom_size\n__prg_rom_size=128\n");
+MAPPER_PRG_ROM_KB(128);
 
 volatile const char c[15000] = {1, [14999] = 2};
 

--- a/test/nes-mmc1/prg-rom-16-fixed.c
+++ b/test/nes-mmc1/prg-rom-16-fixed.c
@@ -1,8 +1,8 @@
+#include <bank.h>
 #include <peekpoke.h>
 #include <stdlib.h>
 
-asm(".globl __prg_rom_size\n"
-    "__prg_rom_size = 16\n");
+MAPPER_PRG_ROM_KB(16);
 
 volatile const char c[15000] = {1, [14999] = 2};
 

--- a/test/nes-mmc1/prg-rom-256.c
+++ b/test/nes-mmc1/prg-rom-256.c
@@ -2,6 +2,8 @@
 #include <peekpoke.h>
 #include <stdlib.h>
 
+MAPPER_PRG_ROM_KB(256);
+
 volatile const char c[15000] = {1, [14999] = 2};
 
 __attribute__((section(".prg_rom_0.rodata"))) volatile const char d[15000] = {

--- a/test/nes-mmc1/prg-rom-32-fixed.c
+++ b/test/nes-mmc1/prg-rom-32-fixed.c
@@ -1,8 +1,8 @@
+#include <bank.h>
 #include <peekpoke.h>
 #include <stdlib.h>
 
-asm(".globl __prg_rom_size\n"
-    "__prg_rom_size = 32\n");
+MAPPER_PRG_ROM_KB(32);
 
 volatile const char c[32000] = {1, [31999] = 2};
 

--- a/test/nes-mmc1/prg-rom-32.c
+++ b/test/nes-mmc1/prg-rom-32.c
@@ -2,7 +2,7 @@
 #include <peekpoke.h>
 #include <stdlib.h>
 
-asm(".global __prg_rom_size\n__prg_rom_size=32\n");
+MAPPER_PRG_ROM_KB(32);
 
 volatile const char c[15000] = {1, [14999] = 2};
 

--- a/test/nes-mmc1/prg-rom-64.c
+++ b/test/nes-mmc1/prg-rom-64.c
@@ -2,7 +2,7 @@
 #include <peekpoke.h>
 #include <stdlib.h>
 
-asm(".global __prg_rom_size\n__prg_rom_size=64\n");
+MAPPER_PRG_ROM_KB(64);
 
 volatile const char c[15000] = {1, [14999] = 2};
 

--- a/test/nes-mmc3/no-compile/prg-ram-too-big.c
+++ b/test/nes-mmc3/no-compile/prg-ram-too-big.c
@@ -1,3 +1,4 @@
-asm(".globl __prg_ram_size\n__prg_ram_size=8\n"
-    ".globl __prg_nvram_size\n__prg_nvram_size=8\n");
+#include <bank.h>
+MAPPER_PRG_RAM_KB(8);
+MAPPER_PRG_NVRAM_KB(8);
 int main(void) { return 0; }

--- a/test/nes-mmc3/no-compile/prg-rom-too-big-fixed.c
+++ b/test/nes-mmc3/no-compile/prg-rom-too-big-fixed.c
@@ -1,2 +1,3 @@
-asm(".globl __prg_rom_size\n__prg_rom_size=64\n");
+#include <bank.h>
+MAPPER_PRG_ROM_KB(64);
 int main(void) { return 0; }

--- a/test/nes-mmc3/no-compile/prg-rom-too-big.c
+++ b/test/nes-mmc3/no-compile/prg-rom-too-big.c
@@ -1,2 +1,3 @@
-asm(".globl __prg_rom_size\n__prg_rom_size=1024\n");
+#include <bank.h>
+MAPPER_PRG_ROM_KB(1024);
 int main(void) { return 0; }

--- a/test/nes-mmc3/no-compile/prg-rom-too-small.c
+++ b/test/nes-mmc3/no-compile/prg-rom-too-small.c
@@ -1,2 +1,3 @@
-asm(".globl __prg_rom_size\n__prg_rom_size=32\n");
+#include <bank.h>
+MAPPER_PRG_ROM_KB(32);
 int main(void) { return 0; }

--- a/test/nes-nrom/no-compile/chr-ram-too-big.c
+++ b/test/nes-nrom/no-compile/chr-ram-too-big.c
@@ -1,3 +1,4 @@
-asm(".globl __chr_ram_size\n__chr_ram_size=8\n");
-asm(".globl __chr_nvram_size\n__chr_nvram_size=8\n");
+#include <bank.h>
+MAPPER_CHR_RAM_KB(8);
+MAPPER_CHR_NVRAM_KB(8);
 int main(void) { return 0; }

--- a/test/nes-nrom/no-compile/chr-rom-non-pow2.c
+++ b/test/nes-nrom/no-compile/chr-rom-non-pow2.c
@@ -1,2 +1,3 @@
-asm(".globl __chr_rom_size\n__chr_rom_size=120");
+#include <bank.h>
+MAPPER_CHR_ROM_KB(120);
 int main(void) { return 0; }

--- a/test/nes-nrom/no-compile/chr-rom-too-big.c
+++ b/test/nes-nrom/no-compile/chr-rom-too-big.c
@@ -1,2 +1,3 @@
-asm(".globl __chr_rom_size\n__chr_rom_size=256");
+#include <bank.h>
+MAPPER_CHR_ROM_KB(256);
 int main(void) { return 0; }

--- a/test/nes-nrom/no-compile/prg-ram-too-big.c
+++ b/test/nes-nrom/no-compile/prg-ram-too-big.c
@@ -1,3 +1,4 @@
-asm(".globl __prg_ram_size\n__prg_ram_size=32\n"
-    ".globl __prg_nvram_size\n__prg_nvram_size=32\n");
+#include <bank.h>
+MAPPER_PRG_RAM_KB(32);
+MAPPER_PRG_NVRAM_KB(32);
 int main(void) { return 0; }

--- a/test/nes-nrom/no-compile/prg-rom-too-big.c
+++ b/test/nes-nrom/no-compile/prg-rom-too-big.c
@@ -1,2 +1,3 @@
-asm(".globl __prg_rom_size\n__prg_rom_size=64\n");
+#include <bank.h>
+MAPPER_PRG_ROM_KB(64);
 int main(void) { return 0; }

--- a/test/nes-unrom-512/chr-ram.c
+++ b/test/nes-unrom-512/chr-ram.c
@@ -3,8 +3,8 @@
 #include <peekpoke.h>
 #include <stdlib.h>
 
-asm(".globl __chr_ram_size\n"
-    "__chr_ram_size = 32\n");
+MAPPER_CHR_ROM_KB(0);
+MAPPER_CHR_RAM_KB(32);
 
 void poke_ppu(unsigned addr, char val) {
   PPU.vram.address = addr >> 8;

--- a/test/nes-unrom-512/chr-rom.c
+++ b/test/nes-unrom-512/chr-rom.c
@@ -3,10 +3,8 @@
 #include <peekpoke.h>
 #include <stdlib.h>
 
-asm(".globl __chr_ram_size\n"
-    "__chr_ram_size = 0\n"
-    ".globl __chr_rom_size\n"
-    "__chr_rom_size = 32\n");
+MAPPER_CHR_ROM_KB(32);
+MAPPER_CHR_RAM_KB(0);
 
 __attribute__((used, section(".chr_rom_0")))
 const char cr0[8192] = {1, [8191] = 2};

--- a/test/nes-unrom-512/chr-swap-split.c
+++ b/test/nes-unrom-512/chr-swap-split.c
@@ -3,10 +3,8 @@
 #include <peekpoke.h>
 #include <stdlib.h>
 
-asm(".globl __chr_ram_size\n"
-    "__chr_ram_size = 0\n"
-    ".globl __chr_rom_size\n"
-    "__chr_rom_size = 32\n");
+MAPPER_CHR_ROM_KB(32);
+MAPPER_CHR_RAM_KB(0);
 
 __attribute__((used, section(".chr_rom_0")))
 const char cr0[8192] = {1, [8191] = 2};

--- a/test/nes-unrom-512/no-compile/chr-ram-too-small-4screen.c
+++ b/test/nes-unrom-512/no-compile/chr-ram-too-small-4screen.c
@@ -1,6 +1,4 @@
 #include <bank.h>
-
-UNROM_512_USE_4_SCREEN_NAMETABLE;
-asm(".globl __chr_ram_size\n__chr_ram_size=16");
-
+MAPPER_USE_4_SCREEN_NAMETABLE;
+MAPPER_CHR_RAM_KB(16);
 int main(void) { return 0; }

--- a/test/nes-unrom-512/no-compile/chr-rom-too-big.c
+++ b/test/nes-unrom-512/no-compile/chr-rom-too-big.c
@@ -1,2 +1,3 @@
-asm(".globl __chr_rom_size\n__chr_rom_size=64");
+#include <bank.h>
+MAPPER_CHR_ROM_KB(64);
 int main(void) { return 0; }

--- a/test/nes-unrom-512/no-compile/prg-rom-too-big.c
+++ b/test/nes-unrom-512/no-compile/prg-rom-too-big.c
@@ -1,2 +1,3 @@
-asm(".globl __prg_rom_size\n__prg_rom_size=1024\n");
+#include <bank.h>
+MAPPER_PRG_ROM_KB(1024);
 int main(void) { return 0; }


### PR DESCRIPTION
Initial proposal before bed for https://github.com/llvm-mos/llvm-mos-sdk/issues/193 - open to suggestion.

The GTROM mapper isn't covered here as it's not merged, yet.