### PR TITLE
[Breaking] Rework MMC1 banking.

### DIFF
--- a/mos-platform/nes-mmc1/bank.c
+++ b/mos-platform/nes-mmc1/bank.c
@@ -83,6 +83,12 @@ mmc1_register_write_retry(unsigned addr, char val) {
 char get_prg_bank(void) { return _PRG_BANK; }
 __attribute__((alias("get_prg_bank"))) char __get_prg_bank(void);
 
+void set_prg_bank(char bank_id) {
+  mmc1_register_write_retry(MMC1_PRG, bank_id);
+  _PRG_BANK = bank_id;
+}
+__attribute__((alias("set_prg_bank"))) void __set_prg_bank(char);
+
 void set_chr_bank_0(char bank_id) {
   defer_chr_bank_0(bank_id);
   split_chr_bank_0(bank_id);

--- a/mos-platform/nes-mmc1/bank.c
+++ b/mos-platform/nes-mmc1/bank.c
@@ -35,7 +35,7 @@ asm(".globl bank_nmi");
 __attribute__((section(".zp.bss"))) volatile char _CHR_BANK0_NEXT;
 __attribute__((section(".zp.bss"))) volatile char _CHR_BANK1_NEXT;
 __attribute__((section(".zp.data"))) volatile char _MMC1_CTRL_NEXT =
-    CHR_ROM_BANK_MODE_4 | MIRROR_VERTICAL;
+    CHR_BANK_MODE_4 | MIRROR_VERTICAL;
 
 __attribute__((section(".zp.bss"))) volatile char _PRG_BANK;
 __attribute__((section(".zp.bss"))) volatile char _CHR_BANK0;

--- a/mos-platform/nes-mmc1/bank.c
+++ b/mos-platform/nes-mmc1/bank.c
@@ -85,14 +85,12 @@ __attribute__((alias("get_prg_bank"))) char __get_prg_bank(void);
 
 void set_chr_bank_0(char bank_id) {
   defer_chr_bank_0(bank_id);
-  mmc1_register_write_retry(MMC1_CHR0, bank_id);
-  _CHR_BANK0 = bank_id;
+  split_chr_bank_0(bank_id);
 }
 
 void set_chr_bank_1(char bank_id) {
   defer_chr_bank_1(bank_id);
-  mmc1_register_write_retry(MMC1_CHR1, bank_id);
-  _CHR_BANK1 = bank_id;
+  split_chr_bank_1(bank_id);
 }
 
 void split_chr_bank_0(char bank_id) {
@@ -140,9 +138,7 @@ void set_chr_bank_1_high(char bank_id) {
 
 void set_mirroring(enum Mirroring mirroring) {
   defer_mirroring(mirroring);
-  char s = _MMC1_CTRL & 0b11100 | mirroring;
-  mmc1_register_write_retry(MMC1_CTRL, s);
-  _MMC1_CTRL = s;
+  split_mirroring(mirroring);
 }
 
 void split_mirroring(enum Mirroring mirroring) {
@@ -162,9 +158,7 @@ void defer_mirroring(enum Mirroring mirroring) {
 
 void set_chr_rom_bank_mode(enum ChrRomBankMode mode) {
   defer_chr_rom_bank_mode(mode);
-  char s = _MMC1_CTRL & 0b01111 | mode;
-  mmc1_register_write_retry(MMC1_CTRL, s);
-  _MMC1_CTRL = s;
+  split_chr_rom_bank_mode(mode);
 }
 
 void split_chr_rom_bank_mode(enum ChrRomBankMode mode) {

--- a/mos-platform/nes-mmc1/bank.c
+++ b/mos-platform/nes-mmc1/bank.c
@@ -71,18 +71,6 @@ mmc1_register_write(unsigned addr, char val) {
   POKE(addr, val);
 }
 
-#if 0
-__attribute__((always_inline)) static inline void
-mmc1_register_write_retry(unsigned addr, char val) {
-  do {
-    _IN_PROGRESS = 1;
-    reset_shift_register();
-    mmc1_register_write(addr, val);
-  } while (!_IN_PROGRESS);
-  _IN_PROGRESS = 0;
-}
-#endif
-
 // Reliably set the given register with the given shadow to (current & cur_mask
 // | val).
 __attribute__((always_inline)) static inline void

--- a/mos-platform/nes-mmc1/bank.c
+++ b/mos-platform/nes-mmc1/bank.c
@@ -200,7 +200,8 @@ void set_mmc1_ctrl(char value) {
 }
 
 void split_mmc1_ctrl(char value) {
-  set_register_bits(MMC1_CTRL, &_MMC1_CTRL, 0, value);
+  set_register_bits(MMC1_CTRL, &_MMC1_CTRL, 0,
+                    value & (chr_bank_mode_mask | mirroring_mask));
 }
 
 void defer_mmc1_ctrl(char value) {

--- a/mos-platform/nes-mmc1/bank.c
+++ b/mos-platform/nes-mmc1/bank.c
@@ -156,12 +156,12 @@ void defer_mirroring(enum Mirroring mirroring) {
   _MMC1_CTRL_NEXT = _MMC1_CTRL_NEXT & 0b01111 | mirroring;
 }
 
-void set_chr_rom_bank_mode(enum ChrRomBankMode mode) {
-  defer_chr_rom_bank_mode(mode);
-  split_chr_rom_bank_mode(mode);
+void set_chr_bank_mode(enum ChrBankMode mode) {
+  defer_chr_bank_mode(mode);
+  split_chr_bank_mode(mode);
 }
 
-void split_chr_rom_bank_mode(enum ChrRomBankMode mode) {
+void split_chr_bank_mode(enum ChrBankMode mode) {
   char s = _MMC1_CTRL & 0b01111 | mode;
   DISABLE_IRQ();
   reset_shift_register();
@@ -172,7 +172,7 @@ void split_chr_rom_bank_mode(enum ChrRomBankMode mode) {
   _IN_PROGRESS = 0;
 }
 
-void defer_chr_rom_bank_mode(enum ChrRomBankMode mode) {
+void defer_chr_bank_mode(enum ChrBankMode mode) {
   _MMC1_CTRL_NEXT = _MMC1_CTRL_NEXT & 0b11100 | mode;
 }
 

--- a/mos-platform/nes-mmc1/bank.h
+++ b/mos-platform/nes-mmc1/bank.h
@@ -33,11 +33,6 @@ extern "C" {
 
 // Contains functions to help with working with multiple PRG/CHR banks
 
-// Access the current settings of MMC1 registers.
-extern volatile const char CHR_BANK0_CUR;
-extern volatile const char CHR_BANK1_CUR;
-extern volatile const char MMC1_CTRL_CUR;
-
 // Maximum level of recursion to allow with banked_call and similar functions.
 #define MAX_BANK_DEPTH 10
 
@@ -54,37 +49,61 @@ __attribute__((leaf)) void set_prg_bank(char bank_id);
 
 // Get the current PRG bank at $8000-bfff.
 // returns: The current bank.
-__attribute__((leaf)) char get_prg_bank(void);
+char get_prg_bank(void);
+
+// NOTE: On some MMC1 boards, the high bits of the CHR bank control PRG-ROM/RAM
+// state. For the functions immediately below, these high bits must be zero; use
+// the high versions of the getters and setters below to reference these bits.
 
 // Set the current 1st 4k chr bank to the bank with this id.
-// this will take effect at the next frame
-// and automatically rewrite at the top of every frame
-__attribute__((leaf)) void set_chr_bank_0(char bank_id);
+// This will take effect immediately and automatically rewrite at the top of
+// every frame
+void set_chr_bank_0(char bank_id);
 
 // Set the current 2nd 4k chr bank to the bank with this id.
-// this will take effect at the next frame
-// and automatically rewrite at the top of every frame
-__attribute__((leaf)) void set_chr_bank_1(char bank_id);
+// This will take effect immediately and automatically rewrite at the top of
+// every frame.
+void set_chr_bank_1(char bank_id);
 
 // Set the current 1st 4k chr bank to the bank with this id.
 // this will take effect immediately, such as for mid screen changes
-// but then will be overwritten by the set_chr_bank_0() value
-// in the next frame.
+// but then will be overwritten by the `[set/defer]_chr_bank_0()` value
+// in the next frame. If interrupted by NMI, may not have any effect.
 void split_chr_bank_0(char bank_id);
 
 // Set the current 2nd 4k chr bank to the bank with this id.
 // this will take effect immediately, such as for mid screen changes
-// but then will be overwritten by the set_chr_bank_1() value
-// in the next frame.
+// but then will be overwritten by the `[set/defer]_chr_bank_1()` value
+// in the next frame. If interrupted by NMI, may not have any effect.
 void split_chr_bank_1(char bank_id);
 
-// Sets the CHR bank 0 register to the given value and retries if interrupted.
-// Persists across NMIs.
-void set_chr_bank_0_retry(char bank_id);
+// Set the current 1st 4k chr bank to the bank with this id.
+// This will take effect at the next frame
+// and automatically rewrite at the top of every frame
+void defer_chr_bank_0(char bank_id);
 
-// Reliably sets the CHR bank 0 register to the given value and retries if
-// interrupted. Persists across NMIs.
-void set_chr_bank_1_retry(char bank_id);
+// Set the current 2nd 4k chr bank to the bank with this id.
+// this will take effect at the next frame
+// and automatically rewrite at the top of every frame
+void defer_chr_bank_1(char bank_id);
+
+// Return the high bits of CHR bank 0 that control PRG-RAM/ROM state. The return
+// value is not shifted.
+char get_chr_bank_0_high(void);
+
+// Sets the high bits of the CHR bank 0 register that control PRG-RAM/ROM state
+// to the given value. The incoming value is not shifted, and the lower bits
+// that control the CHR bank must be zero.
+void set_chr_bank_0_high(char value);
+
+// Return the high bits of CHR bank 1 that control PRG-RAM/ROM state. The return
+// value is not shifted.
+char get_chr_bank_1_high(void);
+
+// Sets the high bits of the CHR bank 1 register that control PRG-RAM/ROM state
+// to the given value. The incoming value is not shifted, and the lower bits
+// that control the CHR bank must be zero.
+void set_chr_bank_1_high(char value);
 
 // if you need to swap CHR banks mid screen, perhaps you need more
 // than 256 unique tiles, first write (one time only) the CHR bank
@@ -97,21 +116,65 @@ void set_chr_bank_1_retry(char bank_id);
 // split(0); ---- wait for sprite zero hit, set X scroll to 0
 // split_chr_bank_0(6) ---- change CHR bank to #6
 
-#define MIRROR_LOWER_BANK 0
-#define MIRROR_UPPER_BANK 1
-#define MIRROR_VERTICAL 2
-#define MIRROR_HORIZONTAL 3
+enum Mirroring {
+  MIRROR_LOWER_BANK = 0,
+  MIRROR_UPPER_BANK,
+  MIRROR_VERTICAL,
+  MIRROR_HORIZONTAL,
+};
 
 // Set the current mirroring mode. Your options are MIRROR_LOWER_BANK,
 // MIRROR_UPPER_BANK, MIRROR_HORIZONTAL, and MIRROR_VERTICAL.
-// LOWER and UPPER are single screen modes.
-__attribute__((leaf)) void set_mirroring(char mirroring);
+// LOWER and UPPER are single screen modes. Applies immediately and reapplies at
+// each NMI.
+void set_mirroring(enum Mirroring mirroring);
 
-// Set all 5 bits of the $8000 MMC1 Control register. Overwrites mirroring
-// setting.
+// Set the mirroring temporarily, but override with the previous setting at next
+// NMI. If interrupted by NMI, may not have any effect.
+void split_mirroring(enum Mirroring mirroring);
+
+// Set the mirroring to be applied automatically at the next NMI.
+void defer_mirroring(enum Mirroring mirroring);
+
+enum ChrRomBankMode {
+  CHR_ROM_BANK_MODE_8 = 0b00000,
+  CHR_ROM_BANK_MODE_4 = 0b10000,
+};
+
+// Set the current CHR-ROM bank mode. Applies immediately and reapplies at
+// each NMI.
+void set_chr_rom_bank_mode(enum ChrRomBankMode mode);
+
+// Set the CHR-ROM bank mode temporarily, but override with the previous setting at next
+// NMI. If interrupted by NMI, may not have any effect.
+void split_chr_rom_bank_mode(enum ChrRomBankMode mode);
+
+// Set the CHR-ROM bank mode to be applied automatically at the next NMI.
+void defer_chr_rom_bank_mode(enum ChrRomBankMode mode);
+
+enum PrgRomBankMode {
+  PRG_ROM_BANK_MODE_32K = 0b00000,
+  PRG_ROM_BANK_MODE_FIXED_8000 = 0b01000,
+  PRG_ROM_BANK_MODE_FIXED_C000 = 0b01100,
+};
+// Change the PRG-ROM bank mode.
+void set_prg_rom_bank_mode(enum PrgRomBankMode mode);
+
+// Return the current PRG-ROM bank mode.
+enum PrgRomBankMode get_prg_rom_bank_mode(void);
+
+// Set all 5 bits of the $8000 MMC1 Control register. The mirroring and CHR-ROM
+// bank mode settings are applied immediately and at future NMIs.
 void set_mmc1_ctrl(char value);
 
-// some things deleted
+// The mirroring and CHR-ROM bank mode settings are applied immediately, but
+// will be overwritten by future NMIs. The PRG-ROM bits are ignored. If
+// interrupted by NMI, may not have any effect.
+void split_mmc1_ctrl(char value);
+
+// The mirroring and CHR-ROM bank mode settings are applied immediately, but
+// will be overwritten by future NMIs. The PRG-ROM bits are ignored.
+void defer_mmc1_ctrl(char value);
 
 #ifdef __cplusplus
 }

--- a/mos-platform/nes-mmc1/bank.h
+++ b/mos-platform/nes-mmc1/bank.h
@@ -47,7 +47,7 @@ __attribute__((leaf, callback(2))) void banked_call(char bank_id,
 // Switch to the given bank (to $8000-bfff). Your prior bank is not saved.
 // Can be used for reading data with a function in the fixed bank.
 // bank_id: The bank to switch to.
-__attribute__((leaf)) void set_prg_bank(char bank_id);
+void set_prg_bank(char bank_id);
 
 // Get the current PRG bank at $8000-bfff.
 // returns: The current bank.

--- a/mos-platform/nes-mmc1/bank.h
+++ b/mos-platform/nes-mmc1/bank.h
@@ -138,21 +138,21 @@ void split_mirroring(enum Mirroring mirroring);
 // Set the mirroring to be applied automatically at the next NMI.
 void defer_mirroring(enum Mirroring mirroring);
 
-enum ChrRomBankMode {
-  CHR_ROM_BANK_MODE_8 = 0b00000,
-  CHR_ROM_BANK_MODE_4 = 0b10000,
+enum ChrBankMode {
+  CHR_BANK_MODE_8 = 0b00000,
+  CHR_BANK_MODE_4 = 0b10000,
 };
 
-// Set the current CHR-ROM bank mode. Applies immediately and reapplies at
+// Set the current CHR bank mode. Applies immediately and reapplies at
 // each NMI. May have no immediate effect if interrupted by NMI.
-void set_chr_rom_bank_mode(enum ChrRomBankMode mode);
+void set_chr_bank_mode(enum ChrBankMode mode);
 
-// Set the CHR-ROM bank mode temporarily, but override with the previous setting
+// Set the CHR bank mode temporarily, but override with the previous setting
 // at next NMI. May have no effect if interrupted by NMI.
-void split_chr_rom_bank_mode(enum ChrRomBankMode mode);
+void split_chr_bank_mode(enum ChrBankMode mode);
 
-// Set the CHR-ROM bank mode to be applied automatically at the next NMI.
-void defer_chr_rom_bank_mode(enum ChrRomBankMode mode);
+// Set the CHR bank mode to be applied automatically at the next NMI.
+void defer_chr_bank_mode(enum ChrBankMode mode);
 
 enum PrgRomBankMode {
   PRG_ROM_BANK_MODE_32K = 0b00000,

--- a/mos-platform/nes-mmc1/bank.h
+++ b/mos-platform/nes-mmc1/bank.h
@@ -57,34 +57,34 @@ char get_prg_bank(void);
 
 // Set the current 1st 4k chr bank to the bank with this id.
 // This will take effect immediately and automatically rewrite at the top of
-// every frame
+// every frame. May have no immediate effect if interrupted by NMI.
 void set_chr_bank_0(char bank_id);
 
 // Set the current 2nd 4k chr bank to the bank with this id.
 // This will take effect immediately and automatically rewrite at the top of
-// every frame.
+// every frame. May have no immediate effect if interrupted by NMI.
 void set_chr_bank_1(char bank_id);
 
 // Set the current 1st 4k chr bank to the bank with this id.
 // this will take effect immediately, such as for mid screen changes
 // but then will be overwritten by the `[set/defer]_chr_bank_0()` value
-// in the next frame. If interrupted by NMI, may not have any effect.
+// in the next frame. May have no effect if interrupted by NMI.
 void split_chr_bank_0(char bank_id);
 
 // Set the current 2nd 4k chr bank to the bank with this id.
 // this will take effect immediately, such as for mid screen changes
 // but then will be overwritten by the `[set/defer]_chr_bank_1()` value
-// in the next frame. If interrupted by NMI, may not have any effect.
+// in the next frame. May have no effect if interrupted by NMI.
 void split_chr_bank_1(char bank_id);
 
 // Set the current 1st 4k chr bank to the bank with this id.
-// This will take effect at the next frame
-// and automatically rewrite at the top of every frame
+// This will take effect at the next frame and automatically rewrite at the top
+// of every frame.
 void defer_chr_bank_0(char bank_id);
 
 // Set the current 2nd 4k chr bank to the bank with this id.
-// this will take effect at the next frame
-// and automatically rewrite at the top of every frame
+// This will take effect at the next frame and automatically rewrite at the top
+// of every frame.
 void defer_chr_bank_1(char bank_id);
 
 // Return the high bits of CHR bank 0 that control PRG-RAM/ROM state. The return
@@ -126,11 +126,11 @@ enum Mirroring {
 // Set the current mirroring mode. Your options are MIRROR_LOWER_BANK,
 // MIRROR_UPPER_BANK, MIRROR_HORIZONTAL, and MIRROR_VERTICAL.
 // LOWER and UPPER are single screen modes. Applies immediately and reapplies at
-// each NMI.
+// each NMI. May have no immediate effect if interrupted by NMI.
 void set_mirroring(enum Mirroring mirroring);
 
 // Set the mirroring temporarily, but override with the previous setting at next
-// NMI. If interrupted by NMI, may not have any effect.
+// NMI. May have no effect if interrupted by NMI.
 void split_mirroring(enum Mirroring mirroring);
 
 // Set the mirroring to be applied automatically at the next NMI.
@@ -142,11 +142,11 @@ enum ChrRomBankMode {
 };
 
 // Set the current CHR-ROM bank mode. Applies immediately and reapplies at
-// each NMI.
+// each NMI. May have no immediate effect if interrupted by NMI.
 void set_chr_rom_bank_mode(enum ChrRomBankMode mode);
 
-// Set the CHR-ROM bank mode temporarily, but override with the previous setting at next
-// NMI. If interrupted by NMI, may not have any effect.
+// Set the CHR-ROM bank mode temporarily, but override with the previous setting
+// at next NMI. May have no effect if interrupted by NMI.
 void split_chr_rom_bank_mode(enum ChrRomBankMode mode);
 
 // Set the CHR-ROM bank mode to be applied automatically at the next NMI.
@@ -168,8 +168,8 @@ enum PrgRomBankMode get_prg_rom_bank_mode(void);
 void set_mmc1_ctrl(char value);
 
 // The mirroring and CHR-ROM bank mode settings are applied immediately, but
-// will be overwritten by future NMIs. The PRG-ROM bits are ignored. If
-// interrupted by NMI, may not have any effect.
+// will be overwritten by future NMIs. The PRG-ROM bits are ignored. May have no
+// effect if interruped by NMI.
 void split_mmc1_ctrl(char value);
 
 // The mirroring and CHR-ROM bank mode settings are applied immediately, but

--- a/mos-platform/nes-mmc1/bank.h
+++ b/mos-platform/nes-mmc1/bank.h
@@ -35,9 +35,6 @@ extern "C" {
 
 // Contains functions to help with working with multiple PRG/CHR banks
 
-// Maximum level of recursion to allow with banked_call and similar functions.
-#define MAX_BANK_DEPTH 10
-
 // Switch to another bank and call this function.
 // Note: Using banked_call to call a second function from within
 // another banked_call is safe.

--- a/mos-platform/nes-mmc1/bank.s
+++ b/mos-platform/nes-mmc1/bank.s
@@ -50,6 +50,13 @@ MMC1_PRG        = $e000
 .globl bank_nmi
 bank_nmi:
         inc __reset_mmc1_byte
+; Flush out the shadow registers, incorporating any NEXT changes. In addition
+; to applying any NEXT settings, this also finishes any writes in progress to
+; ensure that the shadow state and the register state match for the NMI. The
+; state setters contain logic to clean themselves up after detecting an
+; NMI-interrupted write.
+        lda _PRG_BANK
+        mmc1_register_write MMC1_PRG
         lda _CHR_BANK0
         and #__chr_high_mask
         ora _CHR_BANK0_NEXT

--- a/mos-platform/nes-mmc1/bank.s
+++ b/mos-platform/nes-mmc1/bank.s
@@ -105,5 +105,4 @@ banked_call:
         sta __rc19
         jsr __call_indir
         pla
-        jsr __set_prg_bank
-        rts
+        jmp __set_prg_bank

--- a/mos-platform/nes-mmc1/bank.s
+++ b/mos-platform/nes-mmc1/bank.s
@@ -26,110 +26,84 @@
 
 .include "imag.inc"
 
-.zeropage _PRG_BANK, _CHR_BANK0, _CHR_BANK1, _MMC1_CTRL_NMI, _CHR_BANK0_CUR
-.zeropage _CHR_BANK1_CUR, _MMC1_CTRL_CUR, _IN_PROGRESS
+.zeropage _PRG_BANK, _CHR_BANK0, _CHR_BANK1, _MMC1_CTRL, _CHR_BANK0_NEXT
+.zeropage _CHR_BANK1_NEXT, _MMC1_CTRL_NEXT, _IN_PROGRESS
 
-MMC1_CTRL	= $8000
-MMC1_CHR0	= $a000
-MMC1_CHR1	= $c000
-MMC1_PRG	= $e000
+MMC1_CTRL       = $8000
+MMC1_CHR0       = $a000
+MMC1_CHR1       = $c000
+MMC1_PRG        = $e000
 
 ; macro to write to an mmc1 register, which goes one bit at a time, 5 bits wide.
 .macro mmc1_register_write addr
-	.rept 4
-		sta \addr
-		lsr
-	.endr
-	sta \addr
+        .rept 4
+                sta \addr
+                lsr
+        .endr
+        sta \addr
 .endmacro
 
 .section .nmi.100,"axR",@progbits
-	jsr bank_nmi
+        jsr bank_nmi
 
-.section .text.bank_nmi,"ax",@progbits
+.section .text.bank_nmi,"axR",@progbits
 .globl bank_nmi
 bank_nmi:
-	inc __reset_mmc1_byte
-	lda _CHR_BANK0
-	sta _CHR_BANK0_CUR
-	mmc1_register_write MMC1_CHR0
-	lda _CHR_BANK1
-	sta _CHR_BANK1_CUR
-	mmc1_register_write MMC1_CHR1
-	lda _MMC1_CTRL_NMI
-	sta _MMC1_CTRL_CUR
-	mmc1_register_write MMC1_CTRL
-	lda #0
-	sta _IN_PROGRESS
-	rts
-
-.section .text.set_chr_bank_0,"ax",@progbits
-.weak set_chr_bank_0
-set_chr_bank_0:
-	sta _CHR_BANK0
-	rts
-
-.section .text.set_chr_bank_1,"ax",@progbits
-.weak set_chr_bank_1
-set_chr_bank_1:
-	sta _CHR_BANK1
-	rts
-
-.section .text.set_mirroring,"ax",@progbits
-.weak set_mirroring
-set_mirroring:
-	and #0b11
-	sta __rc2
-	lda _MMC1_CTRL_NMI
-	and #0b11100
-	ora __rc2
-	sta _MMC1_CTRL_NMI
-	rts
-
-.section .text.get_prg_bank,"ax",@progbits
-.globl __get_prg_bank
-.weak get_prg_bank
-__get_prg_bank:
-get_prg_bank:
-	lda _PRG_BANK
-	rts
+        inc __reset_mmc1_byte
+        lda _CHR_BANK0
+        and #__chr_high_mask
+        ora _CHR_BANK0_NEXT
+        sta _CHR_BANK0
+        mmc1_register_write MMC1_CHR0
+        lda _CHR_BANK1
+        and #__chr_high_mask
+        ora _CHR_BANK1_NEXT
+        sta _CHR_BANK1
+        mmc1_register_write MMC1_CHR1
+        lda _MMC1_CTRL
+        and #0b01100
+        ora _MMC1_CTRL_NEXT
+        sta _MMC1_CTRL
+        mmc1_register_write MMC1_CTRL
+        lda #0
+        sta _IN_PROGRESS
+        rts
 
 .section .text.set_prg_bank,"ax",@progbits
 .globl __set_prg_bank
-.weak set_prg_bank
+.globl set_prg_bank
 __set_prg_bank:
 set_prg_bank:
-	tay
+        tay
 .Lset:
-	inc __reset_mmc1_byte
-	ldx #1
-	stx _IN_PROGRESS
-	mmc1_register_write MMC1_PRG
-	ldx _IN_PROGRESS
-	beq .Lretry
-	dex
-	stx _IN_PROGRESS
-	sty _PRG_BANK
-	rts
+        inc __reset_mmc1_byte
+        ldx #1
+        stx _IN_PROGRESS
+        mmc1_register_write MMC1_PRG
+        ldx _IN_PROGRESS
+        beq .Lretry
+        dex
+        stx _IN_PROGRESS
+        sty _PRG_BANK
+        rts
 .Lretry:
-	tya
-	jmp .Lset
-
+        tya
+        jmp .Lset
 
 
 .section .text.banked_call,"ax",@progbits
-.weak banked_call
+.globl banked_call
 banked_call:
-	tay
-	lda _PRG_BANK
-	pha
-	tya
-	jsr __set_prg_bank
-	lda __rc2
-	sta __rc18
-	lda __rc3
-	sta __rc19
-	jsr __call_indir
-	pla
-	jsr __set_prg_bank
-	rts
+        tay
+        lda _PRG_BANK
+        pha
+        tya
+        jsr __set_prg_bank
+        lda __rc2
+        sta __rc18
+        lda __rc3
+        sta __rc19
+        jsr __call_indir
+        pla
+        jsr __set_prg_bank
+        rts

--- a/mos-platform/nes-mmc1/bank.s
+++ b/mos-platform/nes-mmc1/bank.s
@@ -69,27 +69,6 @@ bank_nmi:
         sta _IN_PROGRESS
         rts
 
-.section .text.set_prg_bank,"ax",@progbits
-.globl __set_prg_bank
-.globl set_prg_bank
-__set_prg_bank:
-set_prg_bank:
-        tay
-.Lset:
-        inc __reset_mmc1_byte
-        ldx #1
-        stx _IN_PROGRESS
-        mmc1_register_write MMC1_PRG
-        ldx _IN_PROGRESS
-        beq .Lretry
-        dex
-        stx _IN_PROGRESS
-        sty _PRG_BANK
-        rts
-.Lretry:
-        tya
-        jmp .Lset
-
 
 .section .text.banked_call,"ax",@progbits
 .globl banked_call

--- a/mos-platform/nes-mmc1/common.ld
+++ b/mos-platform/nes-mmc1/common.ld
@@ -18,6 +18,23 @@ ASSERT(__prg_nvram_size % 8 == 0,
 ASSERT(__prg_ram_size + __prg_nvram_size <= 32,
        "MMC1 only supports up to 32KiB of PRG-(NV)RAM.")
 
+ASSERT(__prg_ram_size + __prg_nvram_size < 16 ||
+       __chr_rom_size + __chr_ram_size + __chr_nvram_size < 64,
+       "PRG RAM address line conflicts with CHR A15; configure either <16 KiB PRG-RAM or <64 KiB CHR-RAM")
+
+ASSERT(__prg_ram_size + __prg_nvram_size < 32 ||
+       __chr_rom_size + __chr_ram_size + __chr_nvram_size < 32,
+       "PRG RAM address line conflicts with CHR A14; configure either <32 KiB PRG-RAM or <32 KiB CHR-RAM")
+
+/* Some MMC boards use the high bits of the CHR bank registers to control
+ * PRG-ROM/RAM. This computes a pair of AND masks for selecting the low and
+ * high bits of these banks. */
+
+/* This expression starts with all bits set and zeros the high bits not needed
+ * to store the bank number. */
+__chr_low_mask = 0x1f >> 5 - LOG2CEIL((__chr_rom_size + __chr_ram_size + __chr_nvram_size) / 4);
+__chr_high_mask = ~__chr_low_mask & 0x1f;
+
 MEMORY {
   prg_ram_0 : ORIGIN = 0x006000, LENGTH = __prg_ram_size + __prg_nvram_size >= 8  ? 0x2000 : 0
   prg_ram_1 : ORIGIN = 0x016000, LENGTH = __prg_ram_size + __prg_nvram_size >= 16 ? 0x2000 : 0

--- a/test/nes-mmc1/chr-rom.c
+++ b/test/nes-mmc1/chr-rom.c
@@ -21,8 +21,8 @@ void set_4k_banks(void) { set_mmc1_ctrl(0b11100); }
 int main(void) {
   set_4k_banks();
 
-  set_chr_bank_0_retry(0);
-  set_chr_bank_1_retry(31);
+  set_chr_bank_0(0);
+  set_chr_bank_1(31);
   if (read_ppu(0) != 1)
     return EXIT_FAILURE;
   if (read_ppu(4095) != 2)
@@ -32,7 +32,7 @@ int main(void) {
   if (read_ppu(8191) != 4)
     return EXIT_FAILURE;
 
-  set_chr_bank_1_retry(0);
+  set_chr_bank_1(0);
   if (read_ppu(4096) != 1)
     return EXIT_FAILURE;
   if (read_ppu(8191) != 2)

--- a/test/nes-mmc1/prg-ram-c.c
+++ b/test/nes-mmc1/prg-ram-c.c
@@ -2,6 +2,7 @@
 #include <stdlib.h>
 
 asm(".global __prg_ram_size\n__prg_ram_size=32\n");
+asm(".global __chr_rom_size\n__chr_rom_size=16\n");
 
 volatile char c[8100] = {1, [8099] = 2};
 

--- a/test/nes-mmc1/prg-ram.c
+++ b/test/nes-mmc1/prg-ram.c
@@ -3,6 +3,7 @@
 #include <stdlib.h>
 
 asm(".global __prg_ram_size\n__prg_ram_size=32\n");
+asm(".global __chr_rom_size\n__chr_rom_size=16\n");
 asm(".global __prg_rom_size\n__prg_rom_size=128\n");
 
 __attribute__((section(".prg_ram_0.noinit"))) volatile char c[8192];
@@ -11,7 +12,7 @@ __attribute__((section(".prg_ram_3.noinit"))) volatile char d[4097];
 __attribute__((section("_3.noinit"))) volatile char e[4095];
 
 void set_prg_ram_bank(char b) {
-  set_chr_bank_0_retry(CHR_BANK0_CUR & 0b10011 | (b << 2) & 0b1100);
+  set_chr_bank_0_high(get_chr_bank_0_high() & 0b10000 | b << 2);
 }
 
 int main(void) {


### PR DESCRIPTION
This makes the interface for banking on MMC1 more consistent with the other mappers.

- Removed direct access to shadow registers, replacing it with getter functions where required. These values may need to be computed on some mappers, so using functions allows the interfaces to look more similar across mappers. Inlining should completely fold this away.

- Added accessors for the high part of the CHR bank. On some MMC1 boards, this controls PRG-RAM/ROM state, so it must be visibile to allow saving/restoring that state.

- Replaced the retry versions of chr bank setters with ones that reliably control just the high bits. The retry versions were always intended just to control the high bits; this makes this explicit and separate from true CHR bank control.

- The "set" functions that affect PPU/CHR state now take effect immediately, as well as being rewritten on NMI (previously they only did the latter). The "set" and "split" functions are left unreliable with respect to NMI (i.e., NMI may clobber their values), but now internally disable IRQs. New "defer" functions were added to set the NMI state (the previous "set" behavior); these are intrinsically reliable.

- Remove weak from definitions; the library is fairly integrated, so it should be taken or left as a whole, pending a use for replacing specific functions.

- Make mirroring an enum type.

- Default NMI mirroring setting to vertical.

- Add routines to directly control CHR banking mode.