### PR TITLE
Add default cc65 segments

### DIFF
--- a/mos-platform/common/ldscripts/bss-sections.ld
+++ b/mos-platform/common/ldscripts/bss-sections.ld
@@ -1,3 +1,3 @@
 __bss_start = .;
-*(.bss .bss.* COMMON)
+*(.bss .bss.* BSS COMMON)
 __bss_end = .;

--- a/mos-platform/common/ldscripts/data-sections.ld
+++ b/mos-platform/common/ldscripts/data-sections.ld
@@ -1,3 +1,3 @@
 __data_start = .;
-*(.data .data.*)
+*(.data .data.* DATA)
 __data_end = .;

--- a/mos-platform/common/ldscripts/noinit-sections.ld
+++ b/mos-platform/common/ldscripts/noinit-sections.ld
@@ -1,2 +1,2 @@
-*(.noinit .noinit.*)
+*(.noinit .noinit.* NULL INIT ZPSAVE)
 __heap_start = .;

--- a/mos-platform/common/ldscripts/rodata-sections.ld
+++ b/mos-platform/common/ldscripts/rodata-sections.ld
@@ -1,1 +1,1 @@
-*(.rodata .rodata.*)
+*(.rodata .rodata.* RODATA)

--- a/mos-platform/common/ldscripts/text-sections.ld
+++ b/mos-platform/common/ldscripts/text-sections.ld
@@ -10,7 +10,7 @@ _fini = .;
 *(SORT_BY_INIT_PRIORITY(.fini.* .fini))
 *(.fini_rts)
 
-*(.text .text.*)
+*(.text .text.* CODE LOWCODE ONCE STARTUP)
 
 /* A sorted list of initialization function pointers. Used for GCC
 * constructor attribute and C++ global constructors. */

--- a/mos-platform/common/ldscripts/zp-noinit-sections.ld
+++ b/mos-platform/common/ldscripts/zp-noinit-sections.ld
@@ -1,1 +1,1 @@
-*(.zp .zp.* .zeropage .zeropage.* .directpage .directpage.*)
+*(.zp .zp.* .zeropage .zeropage.* .directpage .directpage.* ZEROPAGE)


### PR DESCRIPTION
This allows seamless ca65 integration without altering default platform linker scripts.

See llvm-mos/llvm-mos#395