### PR TITLE
Atari2600 bug fixes

### DIFF
--- a/mos-platform/atari2600-3e/mapper.h
+++ b/mos-platform/atari2600-3e/mapper.h
@@ -13,9 +13,7 @@
 #define MAPPER_XRAM_READ 0x1000
 #define MAPPER_XRAM_WRITE 0x1400
 
-#define MAPPER_CART_ROM_KB(kb) \
-    asm(".globl __cart_rom_size\n__cart_rom_size = " #kb)
-
+#include <mapper_macros.h>
 #include <mapper_rom_single.h>
 #include <mapper_xram_single.h>
 

--- a/mos-platform/atari2600-3e/mapper_3e.c
+++ b/mos-platform/atari2600-3e/mapper_3e.c
@@ -54,7 +54,7 @@ __attribute__((callback(2))) void banked_call_ram(bank_index_t bankId,
   set_current_bank(previous_bank_id);
 }
 
-// From Stella (cartridge auto-detection):
+// From Stella 2023 (cartridge auto-detection):
 // 3E cart RAM bankswitching is triggered by storing the bank number
 // in address 3E using 'STA $3E', ROM bankswitching is triggered by
 // storing the bank number in address 3F using 'STA $3F'.
@@ -63,9 +63,14 @@ __attribute__((callback(2))) void banked_call_ram(bank_index_t bankId,
 // https://github.com/stella-emu/stella/blob/d6224a8a6e30b4b323cde86ade2f05f75dcdfbec/src/emucore/CartDetector.cxx#L4
 // It also only calls the 3E detection routine on powers-of-two,
 // and if it hasn't detected Superchip via repeating bytes.
+//
+// Now, on Stella 2014 (used by Libretro) it's a bit different:
+// uInt8 signature[] = { 0x85, 0x3E, 0xA9, 0x00 };  // STA $3E; LDA #$00
+// So we ought to support both...
 __attribute__((used, retain, section(".rom0"))) static void _stella_signature_3e() {
   asm("sta $3f");
   asm("sta $3e");
+  asm("lda #$00");
   asm("sta $3f");
 }
 // Javatari.js detects 3E as a fallback for weird ROM sizes...

--- a/mos-platform/atari2600-4k/mapper.h
+++ b/mos-platform/atari2600-4k/mapper.h
@@ -5,7 +5,6 @@
 
 #define MAPPER_TYPE_4K
 
-#define MAPPER_CART_ROM_KB(kb) \
-    asm(".globl __cart_rom_size\n__cart_rom_size = " #kb)
+#include <mapper_macros.h>
 
 #endif

--- a/mos-platform/atari2600-common/CMakeLists.txt
+++ b/mos-platform/atari2600-common/CMakeLists.txt
@@ -14,6 +14,7 @@ install(FILES
   atari2600.h
   atari2600_constants.h
   vcslib.h
+  mapper_macros.h
   mapper_rom_single.h
   mapper_rom_multi.h
   mapper_xram_single.h

--- a/mos-platform/atari2600-common/mapper_macros.h
+++ b/mos-platform/atari2600-common/mapper_macros.h
@@ -1,0 +1,24 @@
+#ifndef _MAPPER_MACROS_H
+#define _MAPPER_MACROS_H
+
+#include <mapper.h>
+
+#define MAPPER_CART_ROM_KB(kb) \
+    asm(".globl __cart_rom_size\n__cart_rom_size = " #kb)
+
+#define _STRINGIFY(x) #x
+#define STRINGIFY(x) _STRINGIFY(x)
+
+#ifdef MAPPER_BANKED_ROM
+// section attribute doesn't seem to recognize C "concatenated" "strings"
+#define _CODE_BANK(index) __attribute__((section(".rom" index ".code")))
+#define CODE_BANK(index) _CODE_BANK(STRINGIFY(index))
+#define _RODATA_BANK(index) __attribute__((section(".rom" index ".rodata")))
+#define RODATA_BANK(index) _RODATA_BANK(STRINGIFY(index))
+#else
+#define CODE_BANK(index)
+#define RODATA_BANK(index)
+#endif
+
+#endif
+

--- a/mos-platform/atari2600-common/mapper_xram_single.h
+++ b/mos-platform/atari2600-common/mapper_xram_single.h
@@ -9,6 +9,8 @@
 #ifndef _MAPPER_XRAM_H_
 #define _MAPPER_XRAM_H_
 
+#include <mapper.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -23,9 +25,11 @@ typedef unsigned char ram_bank_t;
 // For example, DECLARE_XRAM_VARIABLE(0, int my_var)
 // creates two variables: my_var_read and my_var_write.
 // NOTE: These variables are not initialized by default.
-#define DECLARE_XRAM_VARIABLE(index, declaration) \
+#define _DECLARE_XRAM_VARIABLE(index, declaration) \
     __attribute__((section(".xram" #index "_read"))) volatile const declaration##_read; \
     __attribute__((section(".xram" #index "_write"))) volatile declaration##_write;
+
+#define DECLARE_XRAM_VARIABLE(index, declaration) _DECLARE_XRAM_VARIABLE(index, declaration)
 
 // Switch in a RAM bank.
 void ram_select(ram_bank_t bank_id);

--- a/mos-platform/atari2600-common/vcs.ld
+++ b/mos-platform/atari2600-common/vcs.ld
@@ -1,8 +1,6 @@
 
 MEMORY {
   zp : ORIGIN = __rc31 + 1, LENGTH = 0x100 - (__rc31 + 1)
-
-  pia_ram (w) : ORIGIN = 0x80, LENGTH = 0x80
 }
 
 /* Provide imaginary (zero page) registers. */
@@ -10,4 +8,4 @@ __rc0 = 0x80;
 INCLUDE imag-regs.ld
 ASSERT(__rc31 == 0x9f, "Inconsistent zero page map.")
 
-REGION_ALIAS("c_writeable", pia_ram)
+REGION_ALIAS("c_writeable", zp)


### PR DESCRIPTION
- Fixed zp section overlapping registers.
- Fixed bank selection macros to accept macro parameters.
- Better Stella signature.