### PR TITLE
Move atexit to cxa-atexit.cc

### DIFF
--- a/mos-platform/common/c/cxa-atexit.cc
+++ b/mos-platform/common/c/cxa-atexit.cc
@@ -109,4 +109,9 @@ int __cxa_atexit(void (*f)(void *), void *p, void * /* dso_handle */) {
   return !RegistrationList::push_front(ExitFunctionStorage{f, p});
 }
 
+int atexit(void (*function)(void)) {
+  return __cxa_atexit(reinterpret_cast<void (*)(void *)>(function), nullptr,
+                      nullptr);
+}
+
 } // extern "C"

--- a/mos-platform/common/c/stdlib.cc
+++ b/mos-platform/common/c/stdlib.cc
@@ -3,7 +3,6 @@
 extern "C" {
 
 void __memset(char *ptr, char value, size_t num);
-void *memcpy(void *dest, const void *src, size_t count);
 
 __attribute__((weak)) void *calloc(size_t num, size_t size) {
   const auto sz = num * size;
@@ -17,11 +16,4 @@ __attribute__((weak)) void *calloc(size_t num, size_t size) {
   return block;
 }
 
-// From cxx_abi.
-int __cxa_atexit(void (*function)(void *), void *data, void *dso);
-
-int atexit(void (*function)(void)) {
-  return __cxa_atexit(reinterpret_cast<void (*)(void *)>(function), nullptr,
-                      nullptr);
-}
 }


### PR DESCRIPTION
atexit should only be brought in if directly referenced, by calloc can
be a libcall in some circumstances. Accordingly, move atexit out of
stdlib.cc (with calloc) into cxa-atexit.cc.
