### PR TITLE
Fix SDK test suite

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -13,65 +13,6 @@ on:
   workflow_dispatch:
   repository_dispatch:
 jobs:
-  build-test-tools:
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Cache test tools
-        id: cache
-        uses: actions/cache@v3
-        with:
-          path: ${{ env.TEST_TOOLS_DIR }}
-          key: ${{ runner.os }}-test-tools-${{ github.workflow_sha }}
-      - name: Set up Go
-        if: steps.cache.outputs.cache-hit != 'true'
-        uses: actions/setup-go@v4
-        with:
-          go-version: '1.21'
-      - name: Build Emutest binary
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: |
-          git clone https://github.com/sehugg/emutest
-          cd emutest
-          go install
-          mkdir -p ${{ env.EMUTEST_DIR }}
-          GOPATH=$(go env GOPATH)
-          cp $GOPATH/bin/emutest ${{ env.EMUTEST_DIR }}
-      - name: Fetch Mesen-X (Mono version)
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: |
-          mkdir -p ${{ env.MESEN_DIR }}
-          cd ${{ env.MESEN_DIR }}
-          curl -Lo mesen.zip https://github.com/NovaSquirrel/Mesen-X/releases/download/1.0.1/Mesen-Linux.2022-05-14.zip
-          unzip mesen.zip
-          chmod +x Mesen.exe
-          echo '#!/bin/sh' > mesen
-          echo "xvfb-run -a /usr/bin/mono $(pwd)/Mesen.exe \"\$@\"" >> mesen
-          chmod +x mesen
-      - name: Build Stella2014 core
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: |
-          git clone https://github.com/libretro/stella2014-libretro
-          cd stella2014-libretro
-          make --silent -j 4
-          mkdir -p ${{ env.LIBRETRO_CORES_DIR }}
-          mv stella2014_libretro.so ${{ env.LIBRETRO_CORES_DIR }}
-      - name: Build FCEUmm core
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: |
-          git clone https://github.com/libretro/libretro-fceumm
-          cd libretro-fceumm
-          make --silent -j 4
-          mkdir -p ${{ env.LIBRETRO_CORES_DIR }}
-          mv fceumm_libretro.so ${{ env.LIBRETRO_CORES_DIR }}
-      - name: Build Mesen-X core
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: |
-          git clone https://github.com/NovaSquirrel/Mesen-X
-          cd Mesen-X/Libretro
-          make --silent -j 4
-          mkdir -p ${{ env.LIBRETRO_CORES_DIR }}
-          mv mesen_libretro.so ${{ env.LIBRETRO_CORES_DIR }}
-
   package:
     runs-on: ${{ matrix.os }}
     needs: build-test-tools
@@ -91,18 +32,54 @@ jobs:
 
       - name: Install MacOS tools
         if: startsWith(matrix.os, 'macos')
-        run: brew update && brew install ninja
+        run: brew update && brew install ninja-build
 
-      - name: Check out the SDK.
-        uses: actions/checkout@v2
-
-      - name: Restore test tools
+      - name: Cache test tools
+        if: startsWith(matrix.os, 'ubuntu')
+        id: cache
         uses: actions/cache@v3
         with:
           path: ${{ env.TEST_TOOLS_DIR }}
           key: ${{ runner.os }}-test-tools-${{ github.workflow_sha }}
-          restore-keys: |
-            ${{ runner.os }}-test-tools-
+
+      - name: Set up Go
+        if: startsWith(matrix.os, 'ubuntu') && steps.cache.outputs.cache-hit != 'true'
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.21'
+
+      - name: Build Emutest binary
+        if: startsWith(matrix.os, 'ubuntu') && steps.cache.outputs.cache-hit != 'true'
+        run: |
+          git clone https://github.com/sehugg/emutest
+          cd emutest
+          go install
+          mkdir -p ${{ env.EMUTEST_DIR }}
+          GOPATH=$(go env GOPATH)
+          cp $GOPATH/bin/emutest ${{ env.EMUTEST_DIR }}
+
+      - name: Build Emutest binary
+        if: startsWith(matrix.os, 'ubuntu') && steps.cache.outputs.cache-hit != 'true'
+        run: |
+          git clone https://github.com/sehugg/emutest
+          cd emutest
+          go install
+          mkdir -p ${{ env.EMUTEST_DIR }}
+          GOPATH=$(go env GOPATH)
+          cp $GOPATH/bin/emutest ${{ env.EMUTEST_DIR }}
+
+      - name: Fetch libretro corees
+        if: startsWith(matrix.os, 'ubuntu') && steps.cache.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p ${{ env.LIBRETRO_CORES_DIR }}
+          cd ${{ env.LIBRETRO_CORES_DIR }}
+          curl -LO http://buildbot.libretro.com/nightly/linux/x86_64/latest/stella2014_libretro.so.zip
+          unzip stella2014_libretro.so.zip
+          curl -LO http://buildbot.libretro.com/nightly/linux/x86_64/latest/mesen_libretro.so.zip
+          unzip mesen_libretro.so.zip
+
+      - name: Check out the SDK.
+        uses: actions/checkout@v2
 
       - name: Copy Mesen settings file.
         if: startsWith(matrix.os, 'ubuntu')

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,7 +53,9 @@ if(NOT CMAKE_CROSSCOMPILING)
   message(STATUS "Emutest test runner: ${EMUTEST_COMMAND}")
 
   find_library(LIBRETRO_STELLA_CORE
-    NAMES stella2014_libretro.so stella2014_libretro.dylib stella2014_libretro.dll
+    NAMES
+    stella2014_libretro.so stella2014_libretro.dylib stella2014_libretro.dll
+    stella_libretro.so stella_libretro.dylib stella_libretro.dll
     PATHS /lib64/libretro ENV LIBRETRO_CORES_DIR)
   message(STATUS "Libretro Stella core: ${LIBRETRO_STELLA_CORE}")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,9 +48,6 @@ if(NOT CMAKE_CROSSCOMPILING)
     endif()
   endif()
 
-  find_program(MESEN_COMMAND NAMES mesen Mesen.exe ENV MESEN_DIR)
-  message(STATUS "Mesen NES emulator: ${MESEN_COMMAND}")
-
   find_program(EMUTEST_COMMAND NAMES emutest emutest.exe
     PATHS ENV EMUTEST_DIR)
   message(STATUS "Emutest test runner: ${EMUTEST_COMMAND}")
@@ -60,15 +57,10 @@ if(NOT CMAKE_CROSSCOMPILING)
     PATHS /lib64/libretro ENV LIBRETRO_CORES_DIR)
   message(STATUS "Libretro Stella core: ${LIBRETRO_STELLA_CORE}")
 
-  find_library(LIBRETRO_FCEUMM_CORE
-    NAMES fceumm_libretro.so fceumm_libretro.dylib fceumm_libretro.dll
-    PATHS /lib64/libretro ENV LIBRETRO_CORES_DIR)
-  message(STATUS "Libretro FCEUMM core: ${LIBRETRO_FCEUMM_CORE}")
-
   find_library(LIBRETRO_MESEN_CORE
     NAMES mesen_libretro.so mesen_libretro.dylib mesen_libretro.dll
     PATHS /lib64/libretro ENV LIBRETRO_CORES_DIR)
-  message(STATUS "Libretro FCEUMM core: ${LIBRETRO_FCEUMM_CORE}")
+  message(STATUS "Libretro MESEN core: ${LIBRETRO_MESEN_CORE}")
 
   # Install toolchain and config file for users of find_package(llvm-mos-sdk).
   # CMake's find_package logic will discover

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -18,7 +18,6 @@ function(add_test_target target)
       -DEMUTEST_COMMAND=${EMUTEST_COMMAND}
       -DLIBRETRO_STELLA_CORE=${LIBRETRO_STELLA_CORE}
       -DLIBRETRO_MESEN_CORE=${LIBRETRO_MESEN_CORE}
-      -DLIBRETRO_FCEUMM_CORE=${LIBRETRO_FCEUMM_CORE}
       -DCMAKE_C_FLAGS=${config_flag}
       -DCMAKE_CXX_FLAGS=${config_flag}
       -DCMAKE_TOOLCHAIN_FILE=${CMAKE_SOURCE_DIR}/cmake/llvm-mos-toolchain.cmake

--- a/test/atari2600-common/test.cmake
+++ b/test/atari2600-common/test.cmake
@@ -11,4 +11,4 @@ add_vcs_test(minimal ../atari2600-common)
 add_vcs_test(zeropage-max ../atari2600-common)
 
 add_vcs_test(frame-simple ../atari2600-common)
-set_property(TEST test-frame-simple PROPERTY ENVIRONMENT EMUTEST_FB_CRC_PASS=3714305448)
+set_property(TEST test-frame-simple PROPERTY ENVIRONMENT EMUTEST_FB_CRC_PASS=2301452584)

--- a/test/mesen.lua
+++ b/test/mesen.lua
@@ -1,2 +1,0 @@
-﻿emu.addMemoryCallback(function(address, value) emu.stop(value) end,
-                      emu.memCallbackType.cpuWrite, 0x4018)

--- a/test/nes-cnrom/chr-swap-split.c
+++ b/test/nes-cnrom/chr-swap-split.c
@@ -1,5 +1,5 @@
-#include <nes.h>
 #include <mapper.h>
+#include <nes.h>
 #include <peekpoke.h>
 #include <stdlib.h>
 
@@ -11,8 +11,14 @@ const char cr0[8192] = {1, [8191] = 2};
 __attribute__((used, section(".chr_rom_3")))
 const char cr3[8192] = {3, [8191] = 4};
 
+volatile char frame_count;
+
+asm(".section .nmi,\"axR\",@progbits\n"
+    "inc frame_count\n");
+
 void ppu_wait_vblank(void) {
-  while (!(PPU.status & 0x80))
+  char next_frame_count = frame_count + 1;
+  while (frame_count != next_frame_count)
     ;
 }
 
@@ -27,7 +33,7 @@ char read_ppu(unsigned ppu_addr) {
 int main(void) {
   // Enable NMI generation.
   PPU.control = 0x80;
-  
+
   ppu_wait_vblank();
 
   // set changes immediately

--- a/test/nes-cnrom/mesen.lua
+++ b/test/nes-cnrom/mesen.lua
@@ -1,2 +1,0 @@
-﻿emu.addMemoryCallback(function(address, value) emu.stop(value) end,
-                      emu.memCallbackType.cpuWrite, 0x4018)

--- a/test/nes-cnrom/test-lib.c
+++ b/test/nes-cnrom/test-lib.c
@@ -1,8 +1,0 @@
-#include <peekpoke.h>
-
-__attribute__((noreturn)) void _exit(int status) {
-  // This is an unused APU test register, so it should be safe to use writing to
-  // this address to report the exit code to the controlling Mesen Lua script.
-  POKE(0x4018, status);
-  __builtin_unreachable();
-}

--- a/test/nes-gtrom/CMakeLists.txt
+++ b/test/nes-gtrom/CMakeLists.txt
@@ -4,14 +4,12 @@ project(test-nes-gtrom LANGUAGES C)
 
 include(../test.cmake)
 
+add_nes_test(chr-ram)
+add_nes_test(chr-rom)
+add_nes_test(chr-swap-split)
 add_nes_test(minimal)
 add_nes_test(prg-rom-512)
 add_nes_test(prg-rom-banked-call)
-add_nes_test(chr-ram)
 add_nes_test(prg-rom-dpcm)
-
-# emulators have trouble with the GTROM 111 mapper using CHR ROM
-add_mesen_mono_test(chr-rom)
-add_mesen_mono_test(chr-swap-split)
 
 add_subdirectory(no-compile)

--- a/test/nes-gtrom/chr-swap-split.c
+++ b/test/nes-gtrom/chr-swap-split.c
@@ -11,8 +11,14 @@ const char cr0[8192] = {1, [8191] = 2};
 __attribute__((used, section(".chr_rom_1")))
 const char cr1[8192] = {3, [8191] = 4};
 
+volatile char frame_count;
+
+asm(".section .nmi,\"axR\",@progbits\n"
+    "inc frame_count\n");
+
 void ppu_wait_vblank(void) {
-  while (!(PPU.status & 0x80))
+  char next_frame_count = frame_count + 1;
+  while (frame_count != next_frame_count)
     ;
 }
 

--- a/test/nes-gtrom/mesen.lua
+++ b/test/nes-gtrom/mesen.lua
@@ -1,2 +1,0 @@
-﻿emu.addMemoryCallback(function(address, value) emu.stop(value) end,
-                      emu.memCallbackType.cpuWrite, 0x4018)

--- a/test/nes-mmc1/mesen.lua
+++ b/test/nes-mmc1/mesen.lua
@@ -1,2 +1,0 @@
-﻿emu.addMemoryCallback(function(address, value) emu.stop(value) end,
-                      emu.memCallbackType.cpuWrite, 0x4018)

--- a/test/nes-mmc1/test-lib.c
+++ b/test/nes-mmc1/test-lib.c
@@ -1,8 +1,0 @@
-#include <peekpoke.h>
-
-__attribute__((noreturn)) void _exit(int status) {
-  // This is an unused APU test register, so it should be safe to use writing to
-  // this address to report the exit code to the controlling Mesen Lua script.
-  POKE(0x4018, status);
-  __builtin_unreachable();
-}

--- a/test/nes-nrom/mesen.lua
+++ b/test/nes-nrom/mesen.lua
@@ -1,2 +1,0 @@
-﻿emu.addMemoryCallback(function(address, value) emu.stop(value) end,
-                      emu.memCallbackType.cpuWrite, 0x4018)

--- a/test/nes-unrom-512/CMakeLists.txt
+++ b/test/nes-unrom-512/CMakeLists.txt
@@ -1,8 +1,11 @@
 cmake_minimum_required(VERSION 3.18)
 
-project(test-nes-unrom-512 LANGUAGES C)
+project(test-nes-unrom-512 LANGUAGES C ASM)
 
 include(../test.cmake)
+
+add_library(mesen-workaround OBJECT mesen-workaround.s)
+link_libraries(mesen-workaround)
 
 add_nes_test(minimal)
 add_nes_test(prg-rom-512)

--- a/test/nes-unrom-512/chr-swap-split.c
+++ b/test/nes-unrom-512/chr-swap-split.c
@@ -1,5 +1,5 @@
-#include <nes.h>
 #include <mapper.h>
+#include <nes.h>
 #include <peekpoke.h>
 #include <stdlib.h>
 
@@ -11,8 +11,14 @@ const char cr0[8192] = {1, [8191] = 2};
 __attribute__((used, section(".chr_rom_3")))
 const char cr3[8192] = {3, [8191] = 4};
 
+volatile char frame_count;
+
+asm(".section .nmi,\"axR\",@progbits\n"
+    "inc frame_count\n");
+
 void ppu_wait_vblank(void) {
-  while (!(PPU.status & 0x80))
+  char next_frame_count = frame_count + 1;
+  while (frame_count != next_frame_count)
     ;
 }
 
@@ -27,7 +33,7 @@ char read_ppu(unsigned ppu_addr) {
 int main(void) {
   // Enable NMI generation.
   PPU.control = 0x80;
-  
+
   ppu_wait_vblank();
 
   // set changes immediately

--- a/test/nes-unrom-512/mesen-workaround.s
+++ b/test/nes-unrom-512/mesen-workaround.s
@@ -1,0 +1,15 @@
+; libretro Mesen has a bug that causes it to crash unless battery is enabled.
+
+; See the following:
+; https://github.com/SourMesen/Mesen/blob/86326e832974d984846ae078e568c023a5f76f1f/Libretro/libretro.cpp#L1051
+;   This issues a state save upon initialization.
+; https://github.com/SourMesen/Mesen/blob/86326e832974d984846ae078e568c023a5f76f1f/Core/UnRom512.h#L51
+;   This initializes a copy of the original PRG ROM, but only if battery.
+; https://github.com/SourMesen/Mesen/blob/86326e832974d984846ae078e568c023a5f76f1f/Core/UnRom512.h#L67
+;   This runs during a state save, but it depends on the PRG ROM copy
+
+; This appears to already have been fixed in Mesen2, but not in MesenX. We
+; should switch to it as soon as there is a libretro core available.
+
+.globl __battery
+__battery = 1

--- a/test/nes-unrom-512/mesen.lua
+++ b/test/nes-unrom-512/mesen.lua
@@ -1,2 +1,0 @@
-﻿emu.addMemoryCallback(function(address, value) emu.stop(value) end,
-                      emu.memCallbackType.cpuWrite, 0x4018)

--- a/test/nes-unrom/mesen.lua
+++ b/test/nes-unrom/mesen.lua
@@ -1,2 +1,0 @@
-﻿emu.addMemoryCallback(function(address, value) emu.stop(value) end,
-                      emu.memCallbackType.cpuWrite, 0x4018)

--- a/test/test-lib-mesen.c
+++ b/test/test-lib-mesen.c
@@ -1,8 +1,0 @@
-#include <peekpoke.h>
-
-__attribute__((noreturn)) void _exit(int status) {
-  // This is an unused APU test register, so it should be safe to use writing to
-  // this address to report the exit code to the controlling Mesen Lua script.
-  POKE(0x4018, status);
-  __builtin_unreachable();
-}

--- a/test/test.cmake
+++ b/test/test.cmake
@@ -6,13 +6,6 @@ target_include_directories(test-lib-mesen PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../
 add_library(test-lib-emutest ${CMAKE_CURRENT_SOURCE_DIR}/../test-lib-emutest.c)
 target_include_directories(test-lib-emutest PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../)
 
-function(add_mesen_mono_test name)
-  add_executable(${name} ${name}.c)
-  target_link_libraries(${name} test-lib-mesen)
-  add_test(NAME test-${name} COMMAND ${MESEN_COMMAND} --testrunner
-           $<TARGET_FILE:${name}> ${CMAKE_CURRENT_SOURCE_DIR}/../mesen.lua)
-endfunction()
-
 function(add_emutest_test name binext source_dir libretro_core)
   add_executable(${name}.${binext} ${source_dir}/${name}.c)
   target_link_libraries(${name}.${binext} test-lib-emutest)

--- a/test/test.cmake
+++ b/test/test.cmake
@@ -1,8 +1,5 @@
 include(CTest)
 
-add_library(test-lib-mesen ${CMAKE_CURRENT_SOURCE_DIR}/../test-lib-mesen.c)
-target_include_directories(test-lib-mesen PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../)
-
 add_library(test-lib-emutest ${CMAKE_CURRENT_SOURCE_DIR}/../test-lib-emutest.c)
 target_include_directories(test-lib-emutest PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../)
 


### PR DESCRIPTION
This improves the SDK test suite, fixing flakiness issues and working around a
Mesen bug. Accordingly, this allows us to depend entirely upon libretro and
emutest; the Mesen Lua tests have been removed. This allows us to simplify our
test setup, since we can now work entirely off of cores fetched from libretro
builders.

- Remove old test libs
- Remove plain mesen tests
- Remove FCEUMM core
- Allow Arch stella package
- Workaround Mesen UNROM-512 bug
- Update stella test CRC
- Fix chr-swap-split test flake
- Download libretro cores from nightly buildbots
