### PR TITLE
fix nes-nrom "no-compile" tests to fail for the right reasons

### DIFF
--- a/test/nes-nrom/no-compile/chr-ram-too-big.c
+++ b/test/nes-nrom/no-compile/chr-ram-too-big.c
@@ -1,4 +1,4 @@
-#include <mapper.h>
+#include <ines.h>
 MAPPER_CHR_RAM_KB(8);
 MAPPER_CHR_NVRAM_KB(8);
 int main(void) { return 0; }

--- a/test/nes-nrom/no-compile/chr-rom-non-pow2.c
+++ b/test/nes-nrom/no-compile/chr-rom-non-pow2.c
@@ -1,3 +1,3 @@
-#include <mapper.h>
+#include <ines.h>
 MAPPER_CHR_ROM_KB(120);
 int main(void) { return 0; }

--- a/test/nes-nrom/no-compile/chr-rom-too-big.c
+++ b/test/nes-nrom/no-compile/chr-rom-too-big.c
@@ -1,3 +1,3 @@
-#include <mapper.h>
+#include <ines.h>
 MAPPER_CHR_ROM_KB(256);
 int main(void) { return 0; }

--- a/test/nes-nrom/no-compile/prg-ram-too-big.c
+++ b/test/nes-nrom/no-compile/prg-ram-too-big.c
@@ -1,4 +1,4 @@
-#include <mapper.h>
+#include <ines.h>
 MAPPER_PRG_RAM_KB(32);
 MAPPER_PRG_NVRAM_KB(32);
 int main(void) { return 0; }

--- a/test/nes-nrom/no-compile/prg-rom-too-big.c
+++ b/test/nes-nrom/no-compile/prg-rom-too-big.c
@@ -1,3 +1,3 @@
-#include <mapper.h>
+#include <ines.h>
 MAPPER_PRG_ROM_KB(64);
 int main(void) { return 0; }


### PR DESCRIPTION
nrom doesn't have mapper.h, use ines.h