### PR TITLE
[atari8-stdcart] test; 16 KiB ROM fit 14 KiB of RODATA

### DIFF
--- a/test/atari8-stdcart/compile/CMakeLists.txt
+++ b/test/atari8-stdcart/compile/CMakeLists.txt
@@ -2,4 +2,5 @@ set_directory_properties(PROPERTIES EXCLUDE_FROM_ALL ON)
 
 add_compile_test(minimal)
 add_compile_test(cart-rom-8-fit-6)
+add_compile_test(cart-rom-16-fit-14)
 add_compile_test(cart-rom-size-declared)

--- a/test/atari8-stdcart/compile/cart-rom-16-fit-14.c
+++ b/test/atari8-stdcart/compile/cart-rom-16-fit-14.c
@@ -1,0 +1,17 @@
+// atari8-stdcart 16 KiB ROM should be able to accommodate 14 KiB of
+// RODATA
+
+#include <stdint.h>
+
+asm(".globl __cart_rom_size \n __cart_rom_size = 16");
+
+const uint8_t data_should_fit[14 * 1024] = { 0x55 };
+
+int main(void) {
+  asm volatile(
+    ""
+    :
+    : "r"(data_should_fit)
+    :
+    );
+}


### PR DESCRIPTION
@mysterymath this should work (lacked const earlier)