### PR TITLE
Rewrite malloc

### DIFF
--- a/mos-platform/common/c/CMakeLists.txt
+++ b/mos-platform/common/c/CMakeLists.txt
@@ -26,6 +26,7 @@ add_platform_library(common-c
   stdlib.c
   stdlib.cc
   malloc.cc
+  malloc.s
   new.cc
 
   # string.h

--- a/mos-platform/common/c/stdlib.cc
+++ b/mos-platform/common/c/stdlib.cc
@@ -8,9 +8,8 @@ __attribute__((weak)) void *calloc(size_t num, size_t size) {
   const auto sz = num * size;
   const auto block = malloc(sz);
 
-  if (!block) {
+  if (!block)
     return nullptr;
-  }
 
   __memset(static_cast<char *>(block), 0, sz);
   return block;

--- a/mos-platform/common/include/stdlib.h
+++ b/mos-platform/common/include/stdlib.h
@@ -82,8 +82,7 @@ Note: if your program does not need to use the heap, then do not call
 any of these functions. The entire heap implementation is only allocated
 in your program if you actually call the allocation functions.
 
-Currently the heap is implemented using a first-fit free list. The heap
-segment is placed directly after BSS in your program.  The heap can
+The heap segment is placed directly after BSS in your program. The heap can
 utilize any of the memory between the base heap address and the top of the
 software-defined stack.
 
@@ -131,9 +130,10 @@ Typical memory map, for a target that loads programs into RAM:
 */
 // clang-format on
 
-void *malloc(size_t size);
+void *aligned_alloc(size_t alignment, size_t size);
+void *calloc(size_t nmemb, size_t size);
 void free(void *ptr);
-void *calloc(size_t num, size_t size);
+void *malloc(size_t size);
 void *realloc(void *ptr, size_t size);
 
 /* The maximum heap size can be limited in the following ways:
@@ -142,8 +142,8 @@ void *realloc(void *ptr, size_t size);
    minimum is only a few bytes, but for practical purposes if you are using the
    heap, you should at least plan on using 100's or 1000's of bytes.
 2. If an allocation is made prior to setting the heap limit, the initial limit
-   is set to an implementation-defined default. The actual limit may depend
-   on the available address space of the target platform.
+   is set to the value of the symbol `__heap_default_limit`. The actual limit
+   may depend on the available address space of the target platform.
 3. After the first allocation has been made, the heap may only increase in size.
    Any attempt to decrease the size of the heap limit will be ignored.
 
@@ -158,7 +158,7 @@ size_t __heap_limit();
 /* Set the maximum size of the heap.  Note the limitations above. */
 /* Setting the heap limit implicitly allocates the heap.  Don't call this
    function if you aren't going to use the heap. */
-void __set_heap_limit(size_t new_size);
+void __set_heap_limit(size_t limit);
 
 /* Return heap bytes in use, including overhead for heap data structures in
    the existing allocations. */

--- a/mos-platform/common/ldscripts/noinit-sections.ld
+++ b/mos-platform/common/ldscripts/noinit-sections.ld
@@ -1,2 +1,3 @@
 *(.noinit .noinit.* NULL INIT ZPSAVE)
-__heap_start = .;
+/* This helps ensure all chunk sizes have the low bit free for use as a flag. */
+__heap_start = ALIGN(2);


### PR DESCRIPTION
This uses Knuth boundary tags to allow constant-time coalescing. The
allocator remains first fit, but with this implementation, all of the
O(n) loops have been removed except for the scan for first fit, which
can exit early.

The free list has been altered to search for chunks in FIFO order; from
Wilson's survey, this is an excellent strategy compared to other simple
approaches, since it maximizes the amount of time a chunk is available
to be coalesced. This minimizes fragmentation, which increases the
expected speed of the first fit scan.

A typical boundary tag implementation requires a boolean tag on each
chunk indicating whether the previous chunk is free. We do this the
usual way: chunks are aligned to 2, and the prev_free tag is the LSB of
the size.

The minimum allocation size remains 8 bytes. Two bytes are used per
allocated chunk for the size and prev_free bit, and one byte of padding
is used at the end for odd sized requests. Other than this, there is now
no additional wasted space to maintain the free list, since the list is
now maintained entirely using the free portions of the heap.

The cost is a modestly increased implementation size. This also includes
an implementation of `aligned_alloc`. But broadly, this is more in line
with what's expected from a modern malloc implementation. The main
improvement possible at this point would be to achieve constant time
allocations using size-segregated free lists, but this would need actual
measurement.
