### PR TITLE
[atari8-common] Use HATABS for __putchar

### DIFF
--- a/mos-platform/atari8-common/putchar.c
+++ b/mos-platform/atari8-common/putchar.c
@@ -14,6 +14,11 @@ __attribute__((always_inline, weak)) void __char_conv(char c,
     emit(c);
 }
 
+// Send character output via HATABS/IOCB0 which the OS opens to "E:"
+// (the screen editor).  This ensures when HATABS is updated, as is
+// the case for 80-column adapters, the output goes to the right
+// place.
+
 // Do NOT inline this.
 //
 // This calls a vector via RTS, then the OS does another RTS to get
@@ -24,9 +29,9 @@ __attribute__((always_inline, weak)) void __char_conv(char c,
 __attribute__((noinline)) void __putchar(char c) {
   // Atari OS EOUTCH routine.
   __attribute__((leaf)) asm volatile("tax\n"
-                                     "lda $e407\n"
+                                     "lda $0347\n"
                                      "pha\n"
-                                     "lda $e406\n"
+                                     "lda $0346\n"
                                      "pha\n"
                                      "txa\n"
                                      "rts\n"


### PR DESCRIPTION
Doing this ensures we get output when HATABS is updated as is the case for 80-column adapters.