### PR TITLE
Make __heap_start relocatable rather than absolute.

### DIFF
--- a/mos-platform/common/ldscripts/noinit-sections.ld
+++ b/mos-platform/common/ldscripts/noinit-sections.ld
@@ -1,3 +1,3 @@
 *(.noinit .noinit.* NULL INIT ZPSAVE)
 /* This helps ensure all chunk sizes have the low bit free for use as a flag. */
-__heap_start = ALIGN(2);
+__heap_start = ALIGN(., 2);

--- a/mos-platform/common/ldscripts/noinit-sections.ld
+++ b/mos-platform/common/ldscripts/noinit-sections.ld
@@ -1,3 +1,7 @@
 *(.noinit .noinit.* NULL INIT ZPSAVE)
-/* This helps ensure all chunk sizes have the low bit free for use as a flag. */
+/* This helps ensure all chunk sizes have the low bit free for use as a flag.
+ * IMPORTANT: it has to be ALIGN(., 2) rather than just ALIGN(2) because the
+ * former generates a relocatable symbol but the latter generates an absolute
+ * symbol. This causes platforms which produce relocatable binaries (e.g.
+ * CP/M-65) to go horribly wrong. */
 __heap_start = ALIGN(., 2);


### PR DESCRIPTION
In the GNU linker language, `ALIGN(alignment)` actually produces an absolute value, while `ALIGN(address, alignment)` produces a relocatable value. See https://sourceware.org/binutils/docs/ld/Builtin-Functions.html#index-ALIGN_0028align_0029 which states that the first is equivalent to `ALIGN(ABSOLUTE(address), alignment)`. Wheee!

This causes `__heap_start` on CP/M-65 to be an absolute value rather than a relocatable one, _even though it's defined in a relocatable segment_, which meant the heap address wasn't getting relocated to the right place, causing big chunks of the program to be overwritten --- with different results on each target platform because they each loaded binaries in different places...