### PR TITLE
MEAG65: Switch "zero page" to $1600 - $16ff

### DIFF
--- a/mos-platform/mega65/CMakeLists.txt
+++ b/mos-platform/mega65/CMakeLists.txt
@@ -16,3 +16,7 @@ add_platform_object_file(mega65-unmap-basic unmap-basic.o unmap-basic.S)
 
 add_platform_library(mega65-c kernal.S)
 target_include_directories(mega65-c BEFORE PUBLIC .)
+
+target_compile_options(mega65-unmap-basic PRIVATE
+    -mcpu=mos45gs02
+)

--- a/mos-platform/mega65/unmap-basic.S
+++ b/mos-platform/mega65/unmap-basic.S
@@ -15,6 +15,9 @@
         ldx #$44 ; unmap all C65 ROMs except $e000-$ffff
         stx $d030
 
+        lda #$16 ; Switch zero page to $1600 - $16ff
+        tab
+
 
 ; restore BASIC ROM after all other exit handlers have completed
 .section .fini.990,"axR", @progbits
@@ -24,7 +27,8 @@
         ; restore C65 ROMs to as before
         ldx #$64
         stx $d030
+
+        lda #$00 ; Switch zero page back to default
+        tab
         
 	cli
-
-


### PR DESCRIPTION
Please follow the discussion here: https://discord.com/channels/1058149494107148399/1058149494107148402/1210065267716259880

### Problem:
The memory between $0000 - $15FF is currently documented as reserved on the MEGA65. llvm-mos currently uses the address $0002 - $0090 for imaginary registers (and more) and therefore conflicts with various ROM routines which are expecting to use the so called Zero-Page for information as well.

### Proposed solution
The CPU on the MEGA65 provides a BP (Base Page) register that is used as high byte for every Load or Store operation with 8bit addresses (so called Zero Page addressing mode). Thus, the Zero-Page (now called Base-Page) can be relocated freely within the first bank.

_This solution_ proposes to use the BP register to relocate all accesses using the 8Bit address mode (Base-Page addressing) to $1600 - $16ff by setting BP to $16. Inline assembly that needs to call any ROM routine, needs to set the BP register back to $00 before entering the kernel and switch back to $16 afterwards.
The performance impact can be held quite low by using this concept.

### Current State:
I've modified the unmap-basic.S so that it is setting the BP to $16. 
I thought about changing `__basic_zp_start` from $0002 to $1602 but I decided against it. `imag-regs.ld` uses this address as base for defining the addresses of the imaginary registers. As these registers should be in the BP and we want still use BP addressing for them, it would make no sense to use 16bit addresses IMHO.

I've discovered that printf() and malloc does not work after this change, unfortunately. Thus, we see side effects.
It needs to be discovered what is the reason for this. 


