### PR TITLE
Disable ZP LTO on CP/M-65

### DIFF
--- a/mos-platform/cpm65/clang.cfg
+++ b/mos-platform/cpm65/clang.cfg
@@ -8,5 +8,6 @@
 -D__CPM65__
 -Wl,-emit-relocs
 -fpost-link-tool=elftocpm65
--mlto-zp=32
+# This doesn't work due to a elftocpm65 bug.
+#-mlto-zp=32
 


### PR DESCRIPTION
This works around the elftocpm65 bug described in #320, at least partially.