### PR TITLE
[Breaking] [supervision] Split sv_lcd_init and sv_lcd_enable.

### DIFF
--- a/mos-platform/supervision/supervision.c
+++ b/mos-platform/supervision/supervision.c
@@ -25,11 +25,14 @@ void sv_lcd_clear(void) {
 	memset(SV_VRAM, 0, SV_VRAM_PITCH * SV_VRAM_HEIGHT);
 }
 
-void sv_lcd_enable(void) {
+void sv_lcd_init(void) {
 	SV_LCD.width = SV_LCD_WIDTH;
 	SV_LCD.height = SV_LCD_HEIGHT;
 	SV_LCD.x = 0;
 	SV_LCD.y = 0;
+}
+
+void sv_lcd_enable(void) {
 	sv_sys_control_set(sv_sys_control_get() | SV_SYS_LCD_ENABLE);
 }
 

--- a/mos-platform/supervision/supervision.h
+++ b/mos-platform/supervision/supervision.h
@@ -162,6 +162,7 @@ struct __sv_sys {
 
 uint8_t sv_sys_control_get(void);
 void sv_sys_control_set(uint8_t value);
+void sv_lcd_init(void);
 void sv_lcd_clear(void);
 void sv_lcd_enable(void);
 void sv_lcd_disable(void);


### PR DESCRIPTION
Technically a breaking change (though nobody uses the target yet), so it would be a good idea to get it in before the next release.

It probably makes more sense this way, but leads to an annoying `sv_lcd_init(); / sv_lcd_clear(); / sv_lcd_enable();` chain in `main()`, if you want to use the LCD, which is a very likely scenario given this is a handheld game console. Maybe it would be a better idea to add an `sv_lcd_init();` call to crt0?