### PR TITLE
[mega65] Fix assertion of ethernet controller struct

### DIFF
--- a/mos-platform/mega65/_45E100.h
+++ b/mos-platform/mega65/_45E100.h
@@ -34,7 +34,7 @@ struct __45E100 {
   uint8_t macaddr[6]; //!< MAC address (offset 0x09)
 };
 #ifdef __cplusplus
-static_assert(sizeof(struct __45E100) == 16);
+static_assert(sizeof(struct __45E100) == 15);
 #endif
 
 /// 45E100 Fast Ethernet controller commands


### PR DESCRIPTION
The size of the ethernet controller struct should be 15 bytes.