### PR TITLE
[Breaking] Make commodore family targets infinitely loop on exit

### DIFF
--- a/mos-platform/commodore/CMakeLists.txt
+++ b/mos-platform/commodore/CMakeLists.txt
@@ -15,7 +15,7 @@ add_platform_library(commodore-crt0)
 merge_libraries(commodore-crt0
   common-copy-zp-data
   common-zero-bss
-  common-exit-return
+  common-exit-loop
 )
 
 add_platform_library(commodore-c


### PR DESCRIPTION
We currently take advantage of the BASIC ZP area, but commodore family
targets can only load programs from a BASIC environment. This makes it
intrinsically unsafe to exit by return, since it always returns to a
possibly-clobbered environment.

Instead, exiting by looping still allows a screen's worth of output to
be viewed, without possibly returning to a broken BASIC interpreter.
This is arguably a bugfix, but it's also a very significant change in
behavior, so I'm considering it a breaking change.

We should also have an optional library that saves and restores BASIC ZP
on entry-exit and exits via returning, but that shouldn't block this
change.
