### PR TITLE
Fix use after free in `_stdio_closeall`

### DIFF
--- a/mos-platform/common/c/stdio-full.c
+++ b/mos-platform/common/c/stdio-full.c
@@ -81,8 +81,11 @@ asm(".section .fini.100,\"axR\",@progbits\n"
     "  jsr _stdio_closeall\n");
 
 void _stdio_closeall(void) {
-  for (FILE *f = filelist; f; f = f->next)
+  for (FILE *f = filelist; f;) {
+    FILE *next = f->next;
     fclose(f);
+    f = next;
+  }
 }
 
 /* A system call that writes a stream's buffer.


### PR DESCRIPTION
While this was probably harmless because we are single-threaded, the allocator could generally store its internal structure in the freed block.