### PR TITLE
KEEP initialization, finalization, NMI, and IRQ sections

### DIFF
--- a/mos-platform/atari2600-3e/init_mapper_3e.S
+++ b/mos-platform/atari2600-3e/init_mapper_3e.S
@@ -2,6 +2,6 @@
 ; so that it matches the __current_bank variable
 ; which is zero-initialized
 
-.section .init.055,"axR",@progbits
+.section .init.055,"ax",@progbits
   sta $3F   ; A = 0 from init.050
 

--- a/mos-platform/atari2600-common/crt0.S
+++ b/mos-platform/atari2600-common/crt0.S
@@ -4,11 +4,11 @@
 ; information.
 ; Originally from cc65. Modified from original version.
 
-.section .init.010,"axR",@progbits
+.section .init.010,"ax",@progbits
 ; Clear decimal mode
         cld
 
-.section .init.050,"axR",@progbits
+.section .init.050,"ax",@progbits
 ; Initialization Loop:
 ; * Clears Atari 2600 whole memory (128 bytes) including BSS segment
 ; * Clears TIA registers
@@ -23,5 +23,5 @@ clearLoop:
 
 ; we jump to main directly here to save 2 bytes of stack
 ; TODO: how do we get rid of "jsr main" in crt0?
-.section .init.400,"axR",@progbits
+.section .init.400,"ax",@progbits
 	jmp	main

--- a/mos-platform/atari8-common/init-stack.S
+++ b/mos-platform/atari8-common/init-stack.S
@@ -3,7 +3,7 @@
 .global __do_init_stack
 
 ; Initialize soft stack pointer to MEMTOP+1
-.section .init.100,"axR",@progbits
+.section .init.100,"ax",@progbits
 __do_init_stack:
   clc
   lda $2e5

--- a/mos-platform/atari8-common/open.s
+++ b/mos-platform/atari8-common/open.s
@@ -112,7 +112,7 @@ ok:     lda     __rc11          ; get fd
 
 ; This must happen after fclosing all stdio files.
 
-.section .fini.200,"axR",@progbits
+.section .fini.200,"ax",@progbits
 closeallfiles:
 
         lda     #MAX_FD_INDEX-1

--- a/mos-platform/c128/init-mmu.S
+++ b/mos-platform/c128/init-mmu.S
@@ -5,13 +5,13 @@ __mmusave:
   .fill 1
 
 ; MMU initialization needs to complete before any CRT initialization
-.section .init.010,"axR",@progbits
+.section .init.010,"ax",@progbits
         lda MMU_CR
         sta __mmusave
         lda MMU_CFG_RAM0_KERNAL ; map $4000-$BFFF to RAM, $C000-$FFFF to KERNAL/chargen
         sta MMU_CR
 
 ; restore MMU state after all other exit handlers have completed
-.section .fini.990,"axR", @progbits
+.section .fini.990,"ax", @progbits
         lda __mmusave
         sta MMU_CR

--- a/mos-platform/c64/unmap-basic.S
+++ b/mos-platform/c64/unmap-basic.S
@@ -5,7 +5,7 @@
 
 
 ; bank switching needs to complete before any CRT initialization
-.section .init.010,"axR",@progbits
+.section .init.010,"ax",@progbits
         ldx #$2F ; restore default CPU I/O port data directions
         stx 0    ;
         ldx #$3E ; LORAM = 0
@@ -14,7 +14,7 @@
 
 
 ; restore BASIC ROM after all other exit handlers have completed
-.section .fini.990,"axR", @progbits
+.section .fini.990,"ax", @progbits
         ldx #$3F ; LORAM = 1
         stx 1    ; switch in BASIC ROM at $A000-$BFFF
 

--- a/mos-platform/commodore/char-conv.c
+++ b/mos-platform/commodore/char-conv.c
@@ -6,7 +6,7 @@
 // The default character conversion used with the screen requires the screen to
 // be in shifted PETSCII, so establish it before it is used. This is done in
 // assembly to avoid pulling in init_array machinery for small programs.
-asm(".section .init.250,\"axR\",@progbits\n"
+asm(".section .init.250,\"ax\",@progbits\n"
     "shift:\n"
     "  lda #0x0e\n"
     "  jsr __CHROUT\n");

--- a/mos-platform/commodore/filevars.s
+++ b/mos-platform/commodore/filevars.s
@@ -20,7 +20,7 @@ curunit:
         .fill    1
 
 
-.section .init,"axR",@progbits
+.section .init,"ax",@progbits
 initcurunit:
         lda     devnum
         bne     1f

--- a/mos-platform/commodore/open.s
+++ b/mos-platform/commodore/open.s
@@ -20,7 +20,7 @@
 
 ; This must happen after fclosing all stdio files.
 
-.section .fini.200,"axR",@progbits
+.section .fini.200,"ax",@progbits
 closeallfiles:
 
         ldx     #MAX_FDS-1

--- a/mos-platform/commodore/read.s
+++ b/mos-platform/commodore/read.s
@@ -24,7 +24,7 @@
 ;--------------------------------------------------------------------------
 ; initstdin: Open the stdin file descriptors for the keyboard
 
-.section .init,"axR",@progbits
+.section .init,"ax",@progbits
   jsr initstdin
 
 .text

--- a/mos-platform/commodore/write.s
+++ b/mos-platform/commodore/write.s
@@ -23,7 +23,7 @@
 ;--------------------------------------------------------------------------
 ; initstdout: Open the stdout and stderr file descriptors for the screen.
 
-.section .init,"axR",@progbits
+.section .init,"ax",@progbits
   jsr initstdout
 
 .text

--- a/mos-platform/common/c/cxa-atexit.cc
+++ b/mos-platform/common/c/cxa-atexit.cc
@@ -6,7 +6,7 @@ static RegistrationList atexit_list;
 
 extern "C" {
 
-asm(".section .fini.100,\"axR\",@progbits\n"
+asm(".section .fini.100,\"ax\",@progbits\n"
     "jsr __do_atexit\n");
 
 void __do_atexit() { atexit_list.run_all_exits(); }

--- a/mos-platform/common/c/stdio-full.c
+++ b/mos-platform/common/c/stdio-full.c
@@ -77,7 +77,7 @@ FILE *stderr = &serr;
 static FILE *filelist = &sin;
 
 // This must happen before all POSIX open files are closed.
-asm(".section .fini.100,\"axR\",@progbits\n"
+asm(".section .fini.100,\"ax\",@progbits\n"
     "  jsr _stdio_closeall\n");
 
 void _stdio_closeall(void) {

--- a/mos-platform/common/crt0/copy-data.c
+++ b/mos-platform/common/crt0/copy-data.c
@@ -1,7 +1,7 @@
 #include <string.h>
 
 asm(".global __do_copy_data\n"
-    ".section .init.200,\"axR\",@progbits\n"
+    ".section .init.200,\"ax\",@progbits\n"
     "__do_copy_data:\n"
     "  jsr __copy_data\n");
 

--- a/mos-platform/common/crt0/copy-zp-data.c
+++ b/mos-platform/common/crt0/copy-zp-data.c
@@ -1,7 +1,7 @@
 #include <string.h>
 
 asm(".global __do_copy_zp_data\n"
-    ".section .init.200,\"axR\",@progbits\n"
+    ".section .init.200,\"ax\",@progbits\n"
     "__do_copy_zp_data:\n"
     "  jsr __copy_zp_data\n");
 

--- a/mos-platform/common/crt0/crt0.S
+++ b/mos-platform/common/crt0/crt0.S
@@ -1,7 +1,7 @@
-.section .call_main,"axR",@progbits
+.section .call_main,"ax",@progbits
   jsr main
 
-.section .fini_rts,"axR",@progbits
+.section .fini_rts,"ax",@progbits
   rts
 
 ; Make sure to search libraries for the after-main code to include.

--- a/mos-platform/common/crt0/exit/exit-custom.S
+++ b/mos-platform/common/crt0/exit/exit-custom.S
@@ -1,4 +1,4 @@
 .global __after_main
-.section .after_main,"axR",@progbits
+.section .after_main,"ax",@progbits
 __after_main:
   jmp exit

--- a/mos-platform/common/crt0/exit/exit-return.c
+++ b/mos-platform/common/crt0/exit/exit-return.c
@@ -1,5 +1,5 @@
 asm(".global __after_main\n"
-    ".section .after_main,\"axR\",@progbits\n"
+    ".section .after_main,\"ax\",@progbits\n"
     "__after_main:\n"
     "  jmp __exit_return\n");
 

--- a/mos-platform/common/crt0/fini-array.c
+++ b/mos-platform/common/crt0/fini-array.c
@@ -2,7 +2,7 @@ typedef void (*func_ptr)(void);
 
 extern func_ptr __fini_array_start[], __fini_array_end[];
 
-asm(".section .fini.200,\"axR\",@progbits\n"
+asm(".section .fini.200,\"ax\",@progbits\n"
     "jsr __do_fini_array\n");
 
 void __do_fini_array(void) {

--- a/mos-platform/common/crt0/init-array.c
+++ b/mos-platform/common/crt0/init-array.c
@@ -2,7 +2,7 @@ typedef void (*func_ptr)(void);
 
 extern func_ptr __init_array_start[], __init_array_end[];
 
-asm(".section .init.300,\"axR\",@progbits\n"
+asm(".section .init.300,\"ax\",@progbits\n"
     "jsr __do_init_array");
 
 void __do_init_array(void) {

--- a/mos-platform/common/crt0/init-stack.S
+++ b/mos-platform/common/crt0/init-stack.S
@@ -3,7 +3,7 @@
 .global __do_init_stack
 
 ; Initialze soft stack pointer from __stack symbol.
-.section .init.100,"axR",@progbits
+.section .init.100,"ax",@progbits
 __do_init_stack:
   lda #mos16lo(__stack)
   sta __rc0

--- a/mos-platform/common/crt0/zero-bss.c
+++ b/mos-platform/common/crt0/zero-bss.c
@@ -4,7 +4,7 @@ extern char __bss_start[];
 extern void __bss_size;
 
 asm(".global __do_zero_bss\n"
-    ".section .init.200,\"axR\",@progbits\n"
+    ".section .init.200,\"ax\",@progbits\n"
     "__do_zero_bss:\n"
     "  jsr __zero_bss\n");
 

--- a/mos-platform/common/crt0/zero-zp-bss.c
+++ b/mos-platform/common/crt0/zero-zp-bss.c
@@ -4,7 +4,7 @@ extern char __zp_bss_start[];
 extern void __zp_bss_size;
 
 asm(".global __do_zero_zp_bss\n"
-    ".section .init.200,\"axR\",@progbits\n"
+    ".section .init.200,\"ax\",@progbits\n"
     "__do_zero_zp_bss:\n"
     "  jsr __zero_zp_bss\n");
 

--- a/mos-platform/common/ldscripts/text-sections.ld
+++ b/mos-platform/common/ldscripts/text-sections.ld
@@ -1,14 +1,14 @@
 /* A mechanism for dynamically building an _init script. */
 _init = .;
 _start = .;
-*(SORT_BY_INIT_PRIORITY(.init.* .init))
-*(.call_main)
-*(.after_main)
+KEEP(*(SORT_BY_INIT_PRIORITY(.init.* .init)))
+KEEP(*(.call_main))
+KEEP(*(.after_main))
 
 /* A mechanism for dynamically building a _fini script. */
 _fini = .;
-*(SORT_BY_INIT_PRIORITY(.fini.* .fini))
-*(.fini_rts)
+KEEP(*(SORT_BY_INIT_PRIORITY(.fini.* .fini)))
+KEEP(*(.fini_rts))
 
 *(.text .text.* CODE LOWCODE ONCE STARTUP)
 

--- a/mos-platform/cpm65/bios.S
+++ b/mos-platform/cpm65/bios.S
@@ -5,7 +5,7 @@
 ; terms of the Apache 2.0 license with the LLVM exceptions. See the LICENSE file
 ; in the project root for the full text.
 
-.section .init.200, "Rax", @progbits
+.section .init.200, "ax", @progbits
 __do_setup_bios:
 	ldy #38
 	jsr BDOS

--- a/mos-platform/cx16/char-conv.c
+++ b/mos-platform/cx16/char-conv.c
@@ -4,7 +4,7 @@
 // The default character conversion used with the screen requires the screen to
 // be in ISO mode, so establish it before it is used. This is done in assembly
 // to avoid pulling in init_array machinery for small programs.
-asm(".section .init.250,\"axR\",@progbits\n"
+asm(".section .init.250,\"ax\",@progbits\n"
     "shift:\n"
     "  lda #0x0f\n"
     "  jsr __CHROUT\n");

--- a/mos-platform/dodo/crt0.s
+++ b/mos-platform/dodo/crt0.s
@@ -1,6 +1,6 @@
 .include "imag.inc"
 
-.section .init.400,"axR",@progbits
+.section .init.400,"ax",@progbits
 	; make sure flags are in a sane state
 	cld
 	cli

--- a/mos-platform/eater/crt0/reset.S
+++ b/mos-platform/eater/crt0/reset.S
@@ -8,7 +8,7 @@
 
 ; Initialize the system from the reset vector.
 .global __do_reset
-.section .init.50,"axR",@progbits
+.section .init.50,"ax",@progbits
 __do_reset:
 ; Fix the D and I flags.
   cld

--- a/mos-platform/eater/crt0/serial.S
+++ b/mos-platform/eater/crt0/serial.S
@@ -14,7 +14,7 @@
 
 ; Initialize the serial port.
 .global __do_init_serial
-.section .init.270,"axR",@progbits
+.section .init.270,"ax",@progbits
 __do_init_serial:
   lda ACIA_STATUS           ; Clear any reported errors.
   lda ACIA_DATA             ; Empty the receive buffer if something is in it.

--- a/mos-platform/eater/crt0/systick.S
+++ b/mos-platform/eater/crt0/systick.S
@@ -16,7 +16,7 @@
 
 ; Initialize the system millisecond tick timer.
 .global __do_init_systick
-.section .init.250,"axR",@progbits
+.section .init.250,"ax",@progbits
 __do_init_systick:
   lda #$a0                      ; Enable T2 interrupts.
   sta VIA_IER

--- a/mos-platform/geos-cbm/crt0.c
+++ b/mos-platform/geos-cbm/crt0.c
@@ -42,13 +42,13 @@ asm(R"ASM(
     )ASM");
 
 asm(R"ASM(
-    .section .init.010,"axR",@progbits
+    .section .init.010,"ax",@progbits
     jsr __swap_userzp
 )ASM");
 
 asm(R"ASM(
                  .global __after_main
-                 .section .after_main,"axR",@progbits
+                 .section .after_main,"ax",@progbits
    __after_main: jsr __swap_userzp
                  jmp __EnterDeskTop
 )ASM");

--- a/mos-platform/mega65/filevars.s
+++ b/mos-platform/mega65/filevars.s
@@ -19,7 +19,7 @@ curunit:
         .fill    1
 
 
-.section .init,"axR",@progbits
+.section .init,"ax",@progbits
 initcurunit:
         lda     #8              ; Default is disk
         sta     curunit

--- a/mos-platform/mega65/unmap-basic.S
+++ b/mos-platform/mega65/unmap-basic.S
@@ -5,7 +5,7 @@
 
 
 ; bank switching needs to complete before any CRT initialization
-.section .init.010,"axR",@progbits
+.section .init.010,"ax",@progbits
 	sei
         ldx #$2F ; restore default CPU I/O port data directions
         stx 0    ;
@@ -17,7 +17,7 @@
 
 
 ; restore BASIC ROM after all other exit handlers have completed
-.section .fini.990,"axR", @progbits
+.section .fini.990,"ax", @progbits
         ldx #$3F ; LORAM = 1
         stx 1    ; switch in BASIC ROM at $A000-$BFFF
 

--- a/mos-platform/nes-action53/mapper.s
+++ b/mos-platform/nes-action53/mapper.s
@@ -31,7 +31,7 @@
 A53_REG_SELECT	= $5000
 A53_REG_VALUE	= $8000
 
-.section .nmi.150,"axR",@progbits
+.section .nmi.150,"ax",@progbits
 .globl swap_chr_bank_nmi
 swap_chr_bank_nmi:
 	lda #$00
@@ -39,7 +39,7 @@ swap_chr_bank_nmi:
 	lda _CHR_BANK_NEXT
 	sta A53_REG_VALUE
 
-.section .nmi.300,"axR",@progbits
+.section .nmi.300,"ax",@progbits
 .globl restore_prg_bank_nmi
 restore_prg_bank_nmi:
 	lda #$01

--- a/mos-platform/nes-cnrom/mapper.c
+++ b/mos-platform/nes-cnrom/mapper.c
@@ -31,7 +31,7 @@ __attribute__((leaf)) void split_chr_bank(char value) {
  * TODO: Adapt to C when the AXY caller convention is present, allowing the
  * compiler to optimize unused shadow variables out.
  */
-asm(".section .nmi.10,\"axR\",@progbits\n"
+asm(".section .nmi.10,\"ax\",@progbits\n"
 	  "lda _BANK_NEXT\n"
 	  "tay\n"
 	  "sta __rom_poke_table,y\n");

--- a/mos-platform/nes-gtrom/mapper.c
+++ b/mos-platform/nes-gtrom/mapper.c
@@ -118,7 +118,7 @@ __attribute__((leaf)) inline void split_nt_bank(char bank_id) {
  * <- NMI writes value to the mapper register
  * store mapper register
  */
-asm(".section .nmi.10,\"axR\",@progbits\n"
+asm(".section .nmi.10,\"ax\",@progbits\n"
     "lda _BANK_NEXT\n"
     "and #$CF\n"
     "ora _CHR_NMI_BANK_NEXT\n"

--- a/mos-platform/nes-mmc1/init-prg-ram-0.s
+++ b/mos-platform/nes-mmc1/init-prg-ram-0.s
@@ -1,4 +1,4 @@
-.section .init.30,"axR",@progbits
+.section .init.30,"ax",@progbits
 lda #0
 sta $a000
 sta $a000

--- a/mos-platform/nes-mmc1/mapper.s
+++ b/mos-platform/nes-mmc1/mapper.s
@@ -43,7 +43,7 @@ MMC1_PRG	= $e000
 	sta \addr
 .endmacro
 
-.section .nmi.100,"axR",@progbits
+.section .nmi.100,"ax",@progbits
 	jsr bank_nmi
 
 .section .text.bank_nmi,"ax",@progbits

--- a/mos-platform/nes-mmc3/init-c-in-prg-ram.s
+++ b/mos-platform/nes-mmc3/init-c-in-prg-ram.s
@@ -4,6 +4,6 @@
 ; information.
 
 ; Set WRAM to read/write
-.section .init.30,"axR",@progbits
+.section .init.30,"ax",@progbits
 lda #$80
 sta $a001

--- a/mos-platform/nes-mmc3/irq.s
+++ b/mos-platform/nes-mmc3/irq.s
@@ -28,12 +28,12 @@
 
 .zeropage __irq_ptr, __irq_index, __irq_done
 
-.section .init.100,"axR",@progbits
+.section .init.100,"ax",@progbits
 	lda #$40
 	sta APU_PAD2
 	jsr __disable_irq
 
-.section .nmi.100,"axR",@progbits
+.section .nmi.100,"ax",@progbits
 	jsr __bank_nmi
 
 .section .text.bank_nmi,"ax",@progbits

--- a/mos-platform/nes-mmc3/reset-banked-mode-1.s
+++ b/mos-platform/nes-mmc3/reset-banked-mode-1.s
@@ -8,6 +8,6 @@ _reset:
   sta $8001
   jmp _start
 
-.section .init.250,"axR",@progbits
+.section .init.250,"ax",@progbits
   lda #$40
   sta __bank_select_hi

--- a/mos-platform/nes-unrom-512/mapper.c
+++ b/mos-platform/nes-unrom-512/mapper.c
@@ -109,7 +109,7 @@ __attribute__((leaf)) inline void split_mirrored_screen(char screen_id) {
  * <- NMI writes value to the mapper register
  * store mapper register
  */
-asm(".section .nmi.10,\"axR\",@progbits\n"
+asm(".section .nmi.10,\"ax\",@progbits\n"
     "lda _BANK_SHADOW\n"
     "and #$1F\n"
     "ora _CHR_BANK_NMI_NEXT\n"

--- a/mos-platform/nes-unrom/mapper.c
+++ b/mos-platform/nes-unrom/mapper.c
@@ -30,7 +30,7 @@ __attribute__((leaf)) void set_prg_bank(char value) {
  * TODO: Adapt to C when the AXY caller convention is present, allowing the
  * compiler to optimize unused shadow variables out.
  */
-asm(".section .nmi.10,\"axR\",@progbits\n"
+asm(".section .nmi.10,\"ax\",@progbits\n"
 	  "lda _BANK_SHADOW\n"
 	  "tay\n"
 	  "sta __rom_poke_table,y\n");

--- a/mos-platform/nes/crt0.c
+++ b/mos-platform/nes/crt0.c
@@ -7,7 +7,7 @@ static void ppu_wait_vblank(void) {
 }
 
 // Set up the hardware stack and launch early initialization.
-asm(".section .init.50,\"axR\",@progbits\n"
+asm(".section .init.50,\"ax\",@progbits\n"
     "  sei\n"
     "  ldx #$ff\n"
     "  txs\n"
@@ -33,7 +33,7 @@ void __early_init(void) {
   // registers.
 }
 
-asm(".section .init.250,\"axR\",@progbits\n"
+asm(".section .init.250,\"ax\",@progbits\n"
     "  jsr __late_init\n");
 
 void __late_init(void) {

--- a/mos-platform/nes/famitone2/famitone2.s
+++ b/mos-platform/nes/famitone2/famitone2.s
@@ -504,7 +504,7 @@ music_pause:
 ; in: none
 ;------------------------------------------------------------------------------
 
-.section .nmi.200,"axR",@progbits
+.section .nmi.200,"ax",@progbits
 	jsr FamiToneUpdate
 
 .section .text.famitone_update,"ax",@progbits

--- a/mos-platform/nes/nes.ld
+++ b/mos-platform/nes/nes.ld
@@ -32,9 +32,9 @@ MEMORY {
 SECTIONS {
   .text : {
        INCLUDE text-sections.ld
-       *(.nmi_begin)
-       *(SORT_BY_INIT_PRIORITY(.nmi.* .nmi))
-       *(.nmi_end)
+       KEEP(*(.nmi_begin))
+       KEEP(*(SORT_BY_INIT_PRIORITY(.nmi.* .nmi)))
+       KEEP(*(.nmi_end))
   } >c_readonly
   INCLUDE rodata.ld
   /* A naturally page-aligned place (0x200) to place noinit buffers with high

--- a/mos-platform/nes/neslib/neslib.s
+++ b/mos-platform/nes/neslib/neslib.s
@@ -16,7 +16,7 @@
 .include "neslib.inc"
 .include "ntsc.inc"
 
-.section .init.100,"axR",@progbits
+.section .init.100,"ax",@progbits
 clearRAM:
     lda #0
     tax
@@ -33,7 +33,7 @@ clearRAM:
     bne 1b
 
 
-.section .init.255,"axR",@progbits
+.section .init.255,"ax",@progbits
 clearPalette:
 	lda #$3f
 	sta PPUADDR
@@ -59,7 +59,7 @@ clearVRAM:
 	bne 1b
 
 
-.section .init.400,"axR",@progbits
+.section .init.400,"ax",@progbits
 .globl neslib_final_init
 neslib_final_init:
 	lda #0
@@ -67,7 +67,7 @@ neslib_final_init:
 	sta PPUSCROLL
 
 
-.section .nmi.050,"axR",@progbits
+.section .nmi.050,"ax",@progbits
 .globl neslib_nmi_begin
 neslib_nmi_begin:
 	lda PPUMASK_VAR	;if rendering is disabled, do not access the VRAM at all
@@ -86,7 +86,7 @@ neslib_nmi_begin:
 
 
 
-.section .nmi.075,"axR",@progbits
+.section .nmi.075,"ax",@progbits
 .globl neslib_nmi_end
 neslib_nmi_end:
 	lda #0

--- a/mos-platform/nes/neslib/ntsc.s
+++ b/mos-platform/nes/neslib/ntsc.s
@@ -3,7 +3,7 @@
 .include "ntsc.inc"
 .include "neslib.inc"
 
-.section .init.275,"axR",@progbits
+.section .init.275,"ax",@progbits
 .globl __do_init_ntsc_mode
 __do_init_ntsc_mode:
 	lda #0b10000000

--- a/mos-platform/nes/neslib/oam_update.s
+++ b/mos-platform/nes/neslib/oam_update.s
@@ -7,13 +7,13 @@
 
 .include "nes.inc"
 
-.section .init.270,"axR",@progbits
+.section .init.270,"ax",@progbits
 .globl oam_update_init
 oam_update_init:
 	jsr oam_clear
 
 
-.section .nmi.055,"axR",@progbits
+.section .nmi.055,"ax",@progbits
 .globl oam_update_nmi
 oam_update_nmi:
         lda #>OAM_BUF

--- a/mos-platform/nes/neslib/pal_bright.s
+++ b/mos-platform/nes/neslib/pal_bright.s
@@ -3,7 +3,7 @@
 ; See https://github.com/llvm-mos/llvm-mos-sdk/blob/main/LICENSE for license
 ; information.
 
-.section .init.260,"axR",@progbits
+.section .init.260,"ax",@progbits
 .globl pal_bright_init
 pal_bright_init:
 	lda #4

--- a/mos-platform/nes/neslib/pal_update.s
+++ b/mos-platform/nes/neslib/pal_update.s
@@ -7,13 +7,13 @@
 
 .include "nes.inc"
 
-.section .init.265,"axR",@progbits
+.section .init.265,"ax",@progbits
 .globl pal_update_init
 pal_update_init:
 	jsr pal_clear
 
 
-.section .nmi.060,"axR",@progbits
+.section .nmi.060,"ax",@progbits
 .globl pal_update_nmi
 pal_update_nmi:
 	lda PAL_UPDATE		;update palette if needed

--- a/mos-platform/nes/neslib/rand.s
+++ b/mos-platform/nes/neslib/rand.s
@@ -1,6 +1,6 @@
  .include "neslib.inc"
 
- .section .init.255,"axR",@progbits
+ .section .init.255,"ax",@progbits
 	lda #$fd
 	sta RAND_SEED
 	sta RAND_SEED+1

--- a/mos-platform/nes/neslib/vram_update.s
+++ b/mos-platform/nes/neslib/vram_update.s
@@ -8,7 +8,7 @@
 .include "nes.inc"
 .include "neslib.inc"
 
-.section .init.280,"axR",@progbits
+.section .init.280,"ax",@progbits
 .globl vram_update_init
 vram_update_init:
 	lda #0
@@ -17,7 +17,7 @@ vram_update_init:
 	jsr set_vram_update
 
 
-.section .nmi.065,"axR",@progbits
+.section .nmi.065,"ax",@progbits
 .globl vram_update_nmi
 vram_update_nmi:
 	lda NAME_UPD_ENABLE

--- a/mos-platform/osi-c1p/crt0.s
+++ b/mos-platform/osi-c1p/crt0.s
@@ -2,6 +2,6 @@
 ; call to main and to initialize the keyboard reading
 ; code.
 
-.section .init.400,"axR",@progbits
+.section .init.400,"ax",@progbits
   jsr __clrscr
 

--- a/mos-platform/pce-cd/crt0/copy-zp-data.S
+++ b/mos-platform/pce-cd/crt0/copy-zp-data.S
@@ -9,6 +9,6 @@
 ; TODO: This would be best to emit in llvm-mos itself.
 
 .global __do_copy_zp_data
-.section .init.200,"axR",@progbits
+.section .init.200,"ax",@progbits
 __do_copy_zp_data:
 	tii __zp_data_start, __zp_data_load_start, #__zp_data_size

--- a/mos-platform/pce-cd/crt0/zero-bss.S
+++ b/mos-platform/pce-cd/crt0/zero-bss.S
@@ -9,7 +9,7 @@
 ; TODO: This would be best to emit in llvm-mos itself.
 
 .global __do_zero_bss
-.section .init.200,"axR",@progbits
+.section .init.200,"ax",@progbits
 __do_zero_bss:
 	stz __bss_start
 	tii __bss_start, __zero_bss_start, #__zero_bss_size

--- a/mos-platform/pce-cd/crt0/zero-zp-bss.S
+++ b/mos-platform/pce-cd/crt0/zero-zp-bss.S
@@ -9,7 +9,7 @@
 ; TODO: This would be best to emit in llvm-mos itself.
 
 .global __do_zero_zp_bss
-.section .init.200,"axR",@progbits
+.section .init.200,"ax",@progbits
 __do_zero_zp_bss:
 	stz __zp_bss_start
 	tii __zp_bss_start, __zero_zp_bss_start, #__zero_zp_bss_size

--- a/mos-platform/pce/crt0/copy-data.S
+++ b/mos-platform/pce/crt0/copy-data.S
@@ -9,6 +9,6 @@
 ; TODO: This would be best to emit in llvm-mos itself.
 
 .global __do_copy_data
-.section .init.200,"axR",@progbits
+.section .init.200,"ax",@progbits
 __do_copy_data:
 	tii __data_start, __data_load_start, #__data_size

--- a/mos-platform/pce/crt0/copy-zp-data.S
+++ b/mos-platform/pce/crt0/copy-zp-data.S
@@ -9,6 +9,6 @@
 ; TODO: This would be best to emit in llvm-mos itself.
 
 .global __do_copy_zp_data
-.section .init.200,"axR",@progbits
+.section .init.200,"ax",@progbits
 __do_copy_zp_data:
 	tii __zp_data_start, __zp_data_load_start, #__zp_data_size

--- a/mos-platform/pce/crt0/crt0.S
+++ b/mos-platform/pce/crt0/crt0.S
@@ -36,7 +36,7 @@ _early_start:
 ; Jump to the real start routine, now that banks are set up.
 	jmp _start
 
-.section .init.50,"axR",@progbits
+.section .init.50,"ax",@progbits
 ; Disable interrupts (MMIO).
 	lda #$07
 	sta $1402

--- a/mos-platform/pce/crt0/zero-bss.S
+++ b/mos-platform/pce/crt0/zero-bss.S
@@ -9,7 +9,7 @@
 ; TODO: This would be best to emit in llvm-mos itself.
 
 .global __do_zero_bss
-.section .init.200,"axR",@progbits
+.section .init.200,"ax",@progbits
 __do_zero_bss:
 	stz __bss_start
 	tii __bss_start, __zero_bss_start, #__zero_bss_size

--- a/mos-platform/pce/crt0/zero-zp-bss.S
+++ b/mos-platform/pce/crt0/zero-zp-bss.S
@@ -9,7 +9,7 @@
 ; TODO: This would be best to emit in llvm-mos itself.
 
 .global __do_zero_zp_bss
-.section .init.200,"axR",@progbits
+.section .init.200,"ax",@progbits
 __do_zero_zp_bss:
 	stz __zp_bss_start
 	tii __zp_bss_start, __zero_zp_bss_start, #__zero_zp_bss_size

--- a/mos-platform/rp6502/init-cpu.s
+++ b/mos-platform/rp6502/init-cpu.s
@@ -1,5 +1,5 @@
 ; Initialize the CPU.
-.section .init.50,"axR",@progbits
+.section .init.50,"ax",@progbits
 ; Fix the D flag.
   cld
 ; Set up the initial 6502 stack pointer.

--- a/mos-platform/rpc8e/crt0.S
+++ b/mos-platform/rpc8e/crt0.S
@@ -6,7 +6,7 @@
 
 .include "imag.inc"
 
-.section .init.50,"axR",@progbits
+.section .init.50,"ax",@progbits
 ; Clear emulation mode.
 	clc
 	xce

--- a/mos-platform/rpc8e/init-stack.S
+++ b/mos-platform/rpc8e/init-stack.S
@@ -9,7 +9,7 @@
 ; Initialize the soft stack by dynamically figuring out the available memory.
 
 .global __do_init_stack
-.section .init.100,"axR",@progbits
+.section .init.100,"ax",@progbits
 __do_init_stack:
 	rep #$30 ; 16-bit index, 16-bit accumulator
 

--- a/mos-platform/supervision/crt0.c
+++ b/mos-platform/supervision/crt0.c
@@ -1,7 +1,7 @@
 #include "supervision.h"
 
 // Set up the hardware stack and launch early initialization.
-asm(".section .init.50,\"axR\",@progbits\n"
+asm(".section .init.50,\"ax\",@progbits\n"
     "  sei\n"
     "  ldx #$ff\n"
     "  txs\n"

--- a/mos-platform/supervision/link.ld
+++ b/mos-platform/supervision/link.ld
@@ -48,9 +48,9 @@ REGION_ALIAS("c_writeable", ram)
 SECTIONS {
   .text : {
        INCLUDE text-sections.ld
-       *(.nmi_begin)
-       *(SORT_BY_INIT_PRIORITY(.nmi.* .nmi))
-       *(.nmi_end)
+       KEEP(*(.nmi_begin))
+       KEEP(*(SORT_BY_INIT_PRIORITY(.nmi.* .nmi)))
+       KEEP(*(.nmi_end))
   } >c_readonly
   INCLUDE rodata.ld
   INCLUDE data.ld

--- a/mos-platform/vic20/init-stack-memtop.S
+++ b/mos-platform/vic20/init-stack-memtop.S
@@ -3,7 +3,7 @@
 .global __do_init_stack
 
 ; Initialze soft stack pointer from KERNAL MEMTOP.
-.section .init.100,"axR",@progbits
+.section .init.100,"ax",@progbits
 __do_init_stack:
   sec
   jsr MEMTOP

--- a/test/nes-cnrom/chr-swap-split.c
+++ b/test/nes-cnrom/chr-swap-split.c
@@ -13,7 +13,7 @@ const char cr3[8192] = {3, [8191] = 4};
 
 volatile char frame_count;
 
-asm(".section .nmi,\"axR\",@progbits\n"
+asm(".section .nmi,\"ax\",@progbits\n"
     "inc frame_count\n");
 
 void ppu_wait_vblank(void) {

--- a/test/nes-gtrom/chr-swap-split.c
+++ b/test/nes-gtrom/chr-swap-split.c
@@ -5,7 +5,7 @@
 
 volatile char frame_count;
 
-asm(".section .nmi,\"axR\",@progbits\n"
+asm(".section .nmi,\"ax\",@progbits\n"
     "inc frame_count\n");
 
 void ppu_wait_vblank(void) {

--- a/test/nes-unrom-512/chr-swap-split.c
+++ b/test/nes-unrom-512/chr-swap-split.c
@@ -13,7 +13,7 @@ const char cr3[8192] = {3, [8191] = 4};
 
 volatile char frame_count;
 
-asm(".section .nmi,\"axR\",@progbits\n"
+asm(".section .nmi,\"ax\",@progbits\n"
     "inc frame_count\n");
 
 void ppu_wait_vblank(void) {


### PR DESCRIPTION
This ensures that any code registered to run at these points is retained by garbage collection, which frees developers from needing to add GNU_RETAIN to their sections. Accordingly, GNU_RETAIN was removed from all such sections in the SDK.

Fixes #391