### PR TITLE
nes/supervision: Add weak attribute to early and late init

### DIFF
--- a/mos-platform/nes/crt0.c
+++ b/mos-platform/nes/crt0.c
@@ -13,7 +13,7 @@ asm(".section .init.50,\"ax\",@progbits\n"
     "  txs\n"
     "  jsr __early_init\n");
 
-void __early_init(void) {
+__attribute__((weak)) void __early_init(void) {
   // Disable NMI generation.
   PPU.control = 0;
   // Disable rendering.
@@ -36,7 +36,7 @@ void __early_init(void) {
 asm(".section .init.250,\"ax\",@progbits\n"
     "  jsr __late_init\n");
 
-void __late_init(void) {
+__attribute__((weak)) void __late_init(void) {
   // Wait for cycle 57165 at the earliest. This is late enough for the PPU to be
   // fully functional and for the main program to begin.
   ppu_wait_vblank();

--- a/mos-platform/supervision/crt0.c
+++ b/mos-platform/supervision/crt0.c
@@ -7,7 +7,7 @@ asm(".section .init.50,\"ax\",@progbits\n"
     "  txs\n"
     "  jsr __early_init\n");
 
-void __early_init(void) {
+__attribute__((weak)) void __early_init(void) {
     // Disable NMI, LCD, configure default bank.
     sv_sys_control_set(SV_SYS_BANK(0) |
                        SV_SYS_NMI_DISABLE |


### PR DESCRIPTION
Useful in cases where custom init is needed.