### PR TITLE
PCE: Fix #389 - regression in .mlb fixed bank symbols.

### DIFF
--- a/mos-platform/pce/_rom-banked-sections.ld
+++ b/mos-platform/pce/_rom-banked-sections.ld
@@ -266,7 +266,7 @@ __rom_vbank0a_bank = 0;
 __rom_vbank0a_lma = __rom_vbank0a;
 __rom_vbank0b = 0x10000 - __rom_bank0_size;
 __rom_vbank0b_size = __rom_bank0_size - 0x2000;
-__rom_vbank0b_offset = 0x2000;
+__rom_vbank0b_offset = __rom_bank0_size > 0x2000 ? 0x2000 : 0;
 __rom_vbank0b_bank = __rom_bank0_size > 0x2000 ? 1 : -1;
 __rom_vbank0b_lma = __rom_vbank0b;
 


### PR DESCRIPTION
For 8KB fixed bank sizes, the virtual banks vbank0a and vbank0b both pointed to the 0xE000 offset, but vbank0b defined the offset as 0x2000, while vbank0a defined the offset as 0.