### PR TITLE
Fix interruptable bank switch for NES-MMC3

### DIFF
--- a/mos-platform/nes-mmc3/mapper.s
+++ b/mos-platform/nes-mmc3/mapper.s
@@ -56,11 +56,11 @@ set_prg_a000:
 
 .section .text.set_reg_retry,"ax",@progbits
 __set_reg_retry:
-	inc __in_progress
+	dec __in_progress
 	sta $8000
 	stx $8001
-	lda __in_progress
-	beq __set_reg_retry
+	bit __in_progress
+	bpl __set_reg_retry
 	lda #0
 	sta __in_progress
 	rts


### PR DESCRIPTION
If an interrupt occurs and the bank switch routine detects that a retry is required, the orignal code has scratched the A register at this stage and it causes a different bank to switch instead. Using BIT in this manner shouldn't cause any incompatibilities due to the possible locations for the RAM value (either in CIRAM or in the mapper SRAM) cannot overlap with any registers on the console.