### PR TITLE
Neo6502 platform API: controller status API

### DIFF
--- a/mos-platform/neo6502/api/controller.c
+++ b/mos-platform/neo6502/api/controller.c
@@ -16,7 +16,8 @@ uint8_t neo_controller_count(void) {
     return ControlPort.params[0];
 }
 
-uint8_t neo_controller_read(uint8_t index) {
+uint32_t neo_controller_read(uint8_t index) {
+    ControlPort.params[0] = index;
     KSendMessageSync(API_GROUP_CONTROLLER, API_FN_READ_CONTROLLER2);
     return *((uint32_t*) ControlPort.params);
 }


### PR DESCRIPTION
file: `mos-platform/neo6502/api/controller.c` [link](https://github.com/llvm-mos/llvm-mos-sdk/blob/main/mos-platform/neo6502/api/controller.c)
function:` uint8_t neo_controller_read(uint8_t index)`
bug 1: return type should be `uint32_t`
bug 2: `index` is not placed in `ControlPort.params[0]` before the API is invoked.
