### PR TITLE
Neo6502: add mouse API support

### DIFF
--- a/mos-platform/neo6502/CMakeLists.txt
+++ b/mos-platform/neo6502/CMakeLists.txt
@@ -34,6 +34,7 @@ add_platform_library(neo6502-c
   api/system.c
   api/turtle.c
   api/uext.c
+  api/mouse.c
   char-conv.c
   clock.c
   getchar.c

--- a/mos-platform/neo6502/api/mouse.c
+++ b/mos-platform/neo6502/api/mouse.c
@@ -1,0 +1,54 @@
+// Copyright 2025 LLVM-MOS Project
+// Licensed under the Apache License, Version 2.0 with LLVM Exceptions.
+// See https://github.com/llvm-mos/llvm-mos-sdk/blob/main/LICENSE for license
+// information.
+
+#include <string.h>
+#include "../neo6502.h"
+#include "../kernel.h"
+#include "api-internal.h"
+
+
+
+// API Group 11, function 1
+void neo_mouse_move_display_cursor(uint16_t x, uint16_t y) {
+  *((volatile uint16_t *)(&ControlPort.params[0])) = x;
+  *((volatile uint16_t *)(&ControlPort.params[2])) = y;
+  KSendMessageSync(API_GROUP_MOUSE, API_FN_MOVE_DISPLAY_CURSOR);
+}
+
+// API Group 11, function 2
+void neo_mouse_set_mouse_display_cursor(uint8_t onOff) {
+  ControlPort.params[0] = onOff;
+  KSendMessageSync(API_GROUP_MOUSE, API_FN_SET_MOUSE_DISPLAY_CURSOR);
+}
+
+// API Group 11, function 3
+void neo_mouse_get_mouse_state(uint16_t *xPos, uint16_t *yPos,
+                               uint8_t *buttonState,
+                               uint8_t *scrollWheelState) {
+  KSendMessageSync(API_GROUP_MOUSE, API_FN_GET_MOUSE_STATE);
+  if (xPos)
+    *xPos = *((volatile uint16_t *)(&ControlPort.params[0]));
+  if (yPos)
+    *yPos = *((volatile uint16_t *)(&ControlPort.params[2]));
+  if (buttonState)
+    *buttonState = ControlPort.params[4];
+  if (scrollWheelState)
+    *scrollWheelState = ControlPort.params[5];
+}
+
+
+// API Group 11, function 4
+uint8_t neo_mouse_test_mouse_present(void) {
+  KSendMessageSync(API_GROUP_MOUSE, API_FN_TEST_MOUSE_PRESENT);
+  return ControlPort.params[0];
+}
+
+
+// API Group 11, function 5
+// note: this API call can set error status; see neo_api_error() 
+void neo_mouse_select_mouse_cursor(uint8_t index) {
+  ControlPort.params[0] = index;
+  KSendMessageSync(API_GROUP_MOUSE, API_FN_SELECT_MOUSE_CURSOR);
+}

--- a/mos-platform/neo6502/api/neo/mouse.h
+++ b/mos-platform/neo6502/api/neo/mouse.h
@@ -1,0 +1,50 @@
+// Copyright 2025 LLVM-MOS Project
+// Licensed under the Apache License, Version 2.0 with LLVM Exceptions.
+// See https://github.com/llvm-mos/llvm-mos-sdk/blob/main/LICENSE for license
+// information.
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#ifndef _NEO_MOUSE_H
+#define _NEO_MOUSE_H
+
+#include <neo6502.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Move display cursor.
+ */
+void neo_mouse_move_display_cursor(uint16_t x, uint16_t y);
+
+/**
+ * @brief Get mouse display cursor on/off.
+ */
+void neo_mouse_set_mouse_display_cursor(uint8_t onOff);
+
+/**
+ * @brief Get mouse state.
+ */
+void neo_mouse_get_mouse_state(uint16_t *xPos, uint16_t *yPos,
+                               uint8_t *buttonState,
+                               uint8_t *scrollWheelState);
+
+/**
+ * @brief test mouse present.
+ */
+uint8_t neo_mouse_test_mouse_present(void);
+
+/**
+ * @brief select mouse cursor.
+ */
+// note: this API call can set error status; see neo_api_error() 
+void neo_mouse_select_mouse_cursor(uint8_t index);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/mos-platform/neo6502/neo6502.h
+++ b/mos-platform/neo6502/neo6502.h
@@ -464,8 +464,14 @@ struct __ControlPort {
 #define API_FN_UART_READ        0x11
 #define API_FN_UART_AVAILABLE   0x12
 
-// TODO: Mouse functions (Group 11)
+// Mouse functions (Group 11)
 #define API_GROUP_MOUSE 0x0B
+#define API_FN_MOVE_DISPLAY_CURSOR 1
+#define API_FN_SET_MOUSE_DISPLAY_CURSOR 2
+#define API_FN_GET_MOUSE_STATE 3
+#define API_FN_TEST_MOUSE_PRESENT 4
+#define API_FN_SELECT_MOUSE_CURSOR 5
+
 
 // TODO: Blitter functions (Group 12)
 #define API_GROUP_BLITTER 0x0C

--- a/mos-platform/neo6502/neo6502.inc
+++ b/mos-platform/neo6502/neo6502.inc
@@ -444,6 +444,12 @@ API_FN_I2C_READ     = $06 ; API function
 API_FN_ANALOG_READ  = $07 ; API function
 API_FN_I2C_STATUs   = $08 ; API function
 
+API_GROUP_MOUSE                         = $0B ; API function group
+API_FN_MOVE_DISPLAY_CURSOR              = $01 ; API function
+API_FN_SET_MOUSE_DISPLAY_CURSOR         = $02 ; API function
+API_FN_GET_MOUSE_STATE                  = $03 ; API function
+API_FN_TEST_MOUSE_PRESENT               = $04 ; API function
+API_FN_SELECT_MOUSE_CURSOR              = $05 ; API function
 
 ;--------;
 ; colors ;


### PR DESCRIPTION
1. Create `mos-platform/neo6502/api/mouse.c` implementing mouse API call glue code
2. Create `mos-platform/neo6502/api/neo/mouse.h` declaring mouse API for C
3. Modify `mos-platform/neo6502/neo6502.h` to add mouse API function numbers
4. Modify `mos-platform/neo6502/neo6502.inc` to add mouse API function numbers
5. Modify `mos-platform/neo6502/CMakeLists.txt` to add `api/mouse.c`

Tried to match asikierka's consistent style throughout