### PR TITLE
Stop __set_heap_size from trashing soft stack

### DIFF
--- a/mos-platform/common/c/malloc.s
+++ b/mos-platform/common/c/malloc.s
@@ -1,2 +1,5 @@
 .weak __heap_default_limit
 __heap_default_limit = 4096
+
+.weak __stack_reserve_size
+__stack_reserve_size = 1024

--- a/mos-platform/common/include/stdlib.h
+++ b/mos-platform/common/include/stdlib.h
@@ -150,8 +150,13 @@ size_t __heap_limit();
 
 /* Set the maximum size of the heap.  Note the limitations above. */
 /* Setting the heap limit implicitly allocates the heap.  Don't call this
-   function if you aren't going to use the heap. */
-void __set_heap_limit(size_t limit);
+ * function if you aren't going to use the heap.  Returns the value actually
+ * set -- this value is capped to avoid trashing the stack. 
+ */
+size_t __set_heap_limit(size_t limit);
+
+/* Return the maximum safe heap size to avoid stack collision. */
+size_t __get_heap_max_safe_size(void);
 
 /* Return heap bytes in use, including overhead for heap data structures in
    the existing allocations. */

--- a/utils/sim/mos-sim.c
+++ b/utils/sim/mos-sim.c
@@ -97,6 +97,7 @@ void write6502(uint16_t address, uint8_t value) {
     exit(value);
   case 0xFFF9:
     putchar(value);
+    fflush(stdout);
     break;
   }
 }


### PR DESCRIPTION
Limit the __set_heap_size function to not trash the stack if too much memory is requested.  Additionally, choose a default stack size and use it as a safety margin when increasing heap size.

The new stack size, __stack_reserve_size, is set weakly to 1024, and anyone who wants to change it can do so without recompiling.

Additionally, the simulator now flushes on stdout output.  This helps establish that long-running tasks are still running on mos-sim.

These changes were necessary to be able to get pi.c to calculate to 50000 digits on the Commodore 64.

