### PR TITLE
Improve mos-sim trace ergonomics

### DIFF
--- a/utils/sim/mos-sim.c
+++ b/utils/sim/mos-sim.c
@@ -195,14 +195,13 @@ int main(int argc, const char *argv[]) {
     }
   }
 
-  char status_buf[9];
-  status_buf[8] = '\0';
-
-  const char statuses[] = "czidb1vn";
-
   reset6502(cmos);
   for (;;) {
-    if (shouldTrace){
+    char status_buf[9];
+    status_buf[8] = '\0';
+    const char statuses[] = "czidb1vn";
+
+    if (shouldTrace) {
       for (int i=0; i<8; ++i) {
         status_buf[7-i] = status&(1<<i) ?
           statuses[i] : '.';


### PR DESCRIPTION
* Changes to --trace formatting to show flag breakdown and instruction stream
* Change 0xfff7 and 0xfff8 to print their final trace line before exiting
* Change to 0xfffe to also trigger halt on read for BRK intercept
