### PR TITLE
added __appram_start parameter

### DIFF
--- a/mos-platform/geos-cbm/geos_memorymap.h
+++ b/mos-platform/geos-cbm/geos_memorymap.h
@@ -12,6 +12,7 @@
 #define GEOS_MEMORYMAP_H
 
 #define SET_OVERLAYSIZE(bytes) asm(".globl __overlaysize_param\n__overlaysize_param = " #bytes)
+#define SET_APPRAM_START(adr) asm(".globl __appram_start_param\n__appram_start_param = " #adr)
 
 #define APP_RAM 0x0400       /** start of application space */
 #define BACK_SCR_BASE 0x6000 /** base of background screen */

--- a/mos-platform/geos-cbm/vlir.ld
+++ b/mos-platform/geos-cbm/vlir.ld
@@ -1,4 +1,5 @@
 __overlaysize   = DEFINED(__overlaysize_param) ? __overlaysize_param : 0x1000;
+__appram_start  = DEFINED(__appram_start_param) ? __appram_start_param : 0x0400;
 
 __backbufsize	= 0x2000;
 __overlayaddr 	= 0x8000 - __backbufsize - __overlaysize;
@@ -9,8 +10,8 @@ __zp_reg_end    = 0xfb;
 __zp_reg_size   = __zp_reg_end - __zp_reg_start;
 
 MEMORY {
-  zp          : ORIGIN = __zp_reg_start, LENGTH = __zp_reg_size
-  vlir00 : ORIGIN = 0x0400, LENGTH = __overlayaddr - __stacksize - 0x0400 
+  zp     : ORIGIN = __zp_reg_start, LENGTH = __zp_reg_size
+  vlir00 : ORIGIN = __appram_start, LENGTH = __overlayaddr - __stacksize - __appram_start 
   vlir01 : ORIGIN = __overlayaddr+0x010000, LENGTH = __overlaysize
   vlir02 : ORIGIN = __overlayaddr+0x020000, LENGTH = __overlaysize
   vlir03 : ORIGIN = __overlayaddr+0x030000, LENGTH = __overlaysize


### PR DESCRIPTION
Some GEOS application do not start at the default address 0x0400. Instead the developer can now define the start address and tell through the SET_APPRAM_START macro.

Anyhow, developer must not forget to give the start address also in the programs info sector.