### PR TITLE
[C128] Add missing initialization of FNAM_BANK ($C7) to 0.

### DIFF
--- a/mos-platform/c128/init-mmu.S
+++ b/mos-platform/c128/init-mmu.S
@@ -10,6 +10,8 @@ __mmusave:
         sta __mmusave
         lda #MMU_CFG_RAM0_KERNAL ; map $4000-$BFFF to RAM, $C000-$FFFF to KERNAL/chargen
         sta MMU_CR
+        lda #0
+        sta FNAM_BANK ; set the bank for the file name to our execution bank
 
 ; restore MMU state after all other exit handlers have completed
 .section .fini.990,"ax", @progbits


### PR DESCRIPTION
This allows open() to work out of the box instead of failing with an error 62 (file not found).

cc65's libsrc/c128/crt0.s does it like this as well.