### PR TITLE
[mega65] Add MEGA65 graphical demo examples

### DIFF
--- a/examples/mega65/CMakeLists.txt
+++ b/examples/mega65/CMakeLists.txt
@@ -14,3 +14,12 @@ add_executable(dma_audio.prg dma_audio.c)
 install_example(dma_audio.prg)
 install(FILES drums.s8 TYPE BIN)
 
+add_executable(mandelbrot.prg mandelbrot.cc)
+install_example(mandelbrot.prg)
+
+add_executable(mandelbrot_fcm.prg mandelbrot_fcm.cc)
+install_example(mandelbrot_fcm.prg)
+
+add_executable(vector_logo.prg vector_logo.cc)
+install_example(vector_logo.prg)
+

--- a/examples/mega65/mandelbrot.cc
+++ b/examples/mega65/mandelbrot.cc
@@ -1,0 +1,156 @@
+// Copyright 2025 LLVM-MOS Project
+// Licensed under the Apache License, Version 2.0 with LLVM Exceptions.
+// See https://github.com/llvm-mos/llvm-mos-sdk/blob/main/LICENSE for license
+// information.
+
+//
+// Fixed-point Mandelbrot set with generated charset and color
+//
+// Uses 8.8 fixed-point arithmetic to compute the classic escape-time
+// fractal. Generates a custom charset with increasing pixel density
+// and maps iteration counts to MEGA65 palette colors.
+// Renders to the 80x25 default screen.
+
+#include <cstdint>
+#include <mega65.h>
+
+// 8.8 fixed-point: high byte = integer, low byte = fraction
+using fix16 = int16_t;
+
+static constexpr fix16 FP_ONE = 256; // 1.0
+static constexpr uint8_t MAX_ITER = 16;
+
+static constexpr uint8_t COLS = 80;
+static constexpr uint8_t ROWS = 25;
+
+// View window: real [-2.0, 0.6], imag [-1.2, 1.2]
+static constexpr fix16 RE_MIN = -2 * FP_ONE;           // -2.0
+static constexpr fix16 RE_MAX = (fix16)(0.6 * FP_ONE); //  0.6
+static constexpr fix16 IM_MIN = (fix16)(-1.2 * FP_ONE);
+static constexpr fix16 IM_MAX = (fix16)(1.2 * FP_ONE);
+
+// Step sizes (pre-computed to avoid division at runtime)
+static constexpr fix16 RE_STEP = (RE_MAX - RE_MIN) / COLS;
+static constexpr fix16 IM_STEP = (IM_MAX - IM_MIN) / ROWS;
+
+static constexpr uint16_t CHARSET_ADDR = 0x3000;
+// 4x4 Bayer ordered-dither matrix, tiled to 8x8.
+// Values 0-15 give 17 threshold levels (0 = no pixels, 16 = all lit).
+// Produces clean, structured fill patterns instead of random noise.
+// clang-format off
+static constexpr uint8_t bayer8x8[8][8] = {
+    { 0, 8, 2,10, 0, 8, 2,10},
+    {12, 4,14, 6,12, 4,14, 6},
+    { 3,11, 1, 9, 3,11, 1, 9},
+    {15, 7,13, 5,15, 7,13, 5},
+    { 0, 8, 2,10, 0, 8, 2,10},
+    {12, 4,14, 6,12, 4,14, 6},
+    { 3,11, 1, 9, 3,11, 1, 9},
+    {15, 7,13, 5,15, 7,13, 5},
+};
+// clang-format on
+
+// Generate 17 characters (0-16) with increasing pixel density.
+// Character 0 = empty, character 16 = solid block.
+// Uses ordered dithering: pixel lights up when char index > Bayer threshold,
+// producing smooth gradient transitions between density levels.
+static void make_charset() {
+  auto *charset = reinterpret_cast<volatile uint8_t *>(CHARSET_ADDR);
+  for (uint8_t ch = 0; ch <= MAX_ITER; ++ch) {
+    for (uint8_t row = 0; row < 8; ++row) {
+      uint8_t pattern = 0;
+      for (uint8_t bit = 0; bit < 8; ++bit) {
+        if (ch > bayer8x8[row][bit])
+          pattern |= (0x80 >> bit);
+      }
+      *charset++ = pattern;
+    }
+  }
+}
+
+// 8.8 fixed-point multiply: (a * b) >> 8
+static inline fix16 fp_mul(fix16 a, fix16 b) {
+  return static_cast<fix16>((static_cast<int32_t>(a) * b) >> 8);
+}
+
+// Compute Mandelbrot iteration count for point (cr, ci)
+static uint8_t mandelbrot(fix16 cr, fix16 ci) {
+  constexpr fix16 FP_FOUR = 4 * FP_ONE; // escape radius squared
+  fix16 zr = 0, zi = 0;
+  for (uint8_t i = 0; i < MAX_ITER; ++i) {
+    fix16 zr2 = fp_mul(zr, zr);
+    fix16 zi2 = fp_mul(zi, zi);
+    if (zr2 + zi2 > FP_FOUR)
+      return i;
+    zi = fp_mul(zr, zi);
+    zi += zi; // 2 * zr * zi
+    zi += ci;
+    zr = zr2 - zi2 + cr;
+  }
+  return MAX_ITER;
+}
+
+static void setup_vic() {
+  // KERNAL uses this zero-page flag to control cursor blinking
+  auto *const CURSOR_BLINK = reinterpret_cast<volatile uint8_t *>(0xCC);
+  *CURSOR_BLINK = 1;
+  asm volatile("sei");
+
+  // Enable MEGA65 fast mode (3.5 MHz) for quicker rendering
+  VICIV.ctrlb |= VIC3_FAST_MASK;
+  // Extend color RAM window to 2KB ($D800-$DFFF) for 80-column mode.
+  // Without this, only $D800-$DBFF (1KB) is visible — not enough
+  // for 80x25=2000 bytes. Hides CIA registers while set.
+  VICIV.ctrla |= VIC3_CRAM2K_MASK;
+
+  make_charset();
+  VICIV.charptr = CHARSET_ADDR;
+}
+
+static void render_fractal() {
+  // Color palette using standard C64 16 colors (0x00-0x0F).
+  // VIC-III attribute mode repurposes bit 4 as blink, so extended
+  // palette colors (>=0x10) cannot be used in color RAM directly.
+  static constexpr uint8_t colors[] = {
+      COLOR_BLUE,       // 0  - escaped immediately
+      COLOR_BLUE,       // 1
+      COLOR_LIGHTBLUE,  // 2
+      COLOR_LIGHTBLUE,  // 3
+      COLOR_CYAN,       // 4
+      COLOR_CYAN,       // 5
+      COLOR_LIGHTGREEN, // 6
+      COLOR_GREEN,      // 7
+      COLOR_YELLOW,     // 8
+      COLOR_YELLOW,     // 9
+      COLOR_ORANGE,     // 10
+      COLOR_ORANGE,     // 11
+      COLOR_RED,        // 12
+      COLOR_LIGHTRED,   // 13
+      COLOR_BROWN,      // 14
+      COLOR_WHITE,      // 15
+      COLOR_BLACK,      // 16 - set member
+  };
+  constexpr uint16_t COLOR_RAM_ADDR = 0xD800;
+  auto *screen = reinterpret_cast<volatile uint8_t *>(&DEFAULT_SCREEN);
+  auto *color = reinterpret_cast<volatile uint8_t *>(COLOR_RAM_ADDR);
+
+  fix16 ci = IM_MIN;
+  for (uint8_t row = 0; row < ROWS; ++row) {
+    fix16 cr = RE_MIN;
+    for (uint8_t col = 0; col < COLS; ++col) {
+      uint8_t iter = mandelbrot(cr, ci);
+      *screen++ = iter;
+      *color++ = colors[iter];
+      cr += RE_STEP;
+    }
+    ci += IM_STEP;
+  }
+}
+
+int main() {
+  setup_vic();
+  render_fractal();
+
+  while (true)
+    ;
+}

--- a/examples/mega65/mandelbrot_fcm.cc
+++ b/examples/mega65/mandelbrot_fcm.cc
@@ -1,0 +1,270 @@
+// Copyright 2025 LLVM-MOS Project
+// Licensed under the Apache License, Version 2.0 with LLVM Exceptions.
+// See https://github.com/llvm-mos/llvm-mos-sdk/blob/main/LICENSE for license
+// information.
+
+//
+// Full Color Mode (FCM) Mandelbrot set for MEGA65
+//
+// Renders the escape-time fractal at 320x200 with per-pixel palette
+// coloring using VIC-IV Full Color Mode. Unlike the hires bitmap version
+// (limited to 2 colors per 8x8 cell), each FCM pixel independently
+// indexes a palette entry — eliminating the color blockiness inherent
+// in character-cell-based graphics.
+//
+// MEGA65 features used:
+//   - VIC-IV Full Color Mode: CHR16 + FCLRHI give each pixel in an
+//     8x8 tile its own 8-bit palette index (256 colors per pixel)
+//   - Hardware math accelerator ($D768): 32x32->64 bit multiply
+//     replaces the slow __mulsi3 software multiply in the hot loop
+//   - Enhanced DMA controller: copies rendered tile rows from CPU RAM
+//     to graphics memory at $40000 (outside 16-bit address space)
+//   - Custom palette RAM ($D100): 33-color gradient
+//   - Full speed mode (~40 MHz)
+//
+// Memory layout:
+//   Screen RAM:  $0800-$0FA7  (2000 bytes, 16-bit tile indices)
+//   Color RAM:   $D800-$DBE7  (1000 bytes, FCM attributes per tile)
+//   Tile buffer: (BSS)        (2560 bytes, rendered one row at a time)
+//   Tile data:   $40000+      (64000 bytes, 1000 tiles x 64 bytes each)
+
+#include <cstdint>
+#include <dma.hpp>
+#include <mega65.h>
+
+using namespace mega65::dma;
+
+// 8.8 fixed-point: high byte = integer, low byte = fraction
+using fix16 = int16_t;
+
+static constexpr fix16 FP_ONE = 256;
+static constexpr uint8_t MAX_ITER = 32;
+
+static constexpr uint8_t CELL_COLS = 40;
+static constexpr uint8_t CELL_ROWS = 25;
+static constexpr uint8_t TILE_PIXELS = 8;
+static constexpr uint16_t TILE_BYTES = TILE_PIXELS * TILE_PIXELS; // 64
+static constexpr uint16_t TILE_ROW_BYTES = CELL_COLS * TILE_BYTES;
+// FCM tile addressing: charptr=0, so tile N maps to bytes [N*64, N*64+63].
+// Graphics at $40000 → first tile index = $40000/64 = 4096.
+static constexpr uint32_t GFX_ADDR = 0x40000UL;
+
+// CPU-side buffer for one tile row (40 tiles x 64 bytes = 2560 bytes),
+// DMA-copied to graphics memory after each row is computed.
+static uint8_t tile_row_buf[TILE_ROW_BYTES];
+
+static inline fix16 fp_mul(fix16 a, fix16 b) {
+  // Set to false to use software multiply (__mulsi3) instead of the
+  // hardware math accelerator — useful for benchmarking the speedup.
+  constexpr bool USE_HW_MATH = true;
+  if constexpr (USE_HW_MATH) {
+    // Sign-extend 16-bit inputs to 32 bits. The hardware performs unsigned
+    // 32x32->64 multiply, but the lower 32 bits match the signed result
+    // when both operands have the same width.
+    MATH.multina32 = static_cast<int32_t>(a);
+    MATH.multinb32 = static_cast<int32_t>(b);
+    // Compiler barrier: ensure both MMIO writes complete before the read.
+    asm volatile("" ::: "memory");
+    return static_cast<fix16>(static_cast<int32_t>(MATH.multout32) >> 8);
+  } else {
+    return static_cast<fix16>(static_cast<int32_t>(a) * b >> 8);
+  }
+}
+
+static uint8_t mandelbrot(fix16 cr, fix16 ci) {
+  constexpr fix16 FP_FOUR = 4 * FP_ONE;
+  fix16 zr = 0, zi = 0;
+  for (uint8_t i = 0; i < MAX_ITER; ++i) {
+    fix16 zr2 = fp_mul(zr, zr);
+    fix16 zi2 = fp_mul(zi, zi);
+    if (zr2 + zi2 > FP_FOUR)
+      return i;
+    zi = fp_mul(zr, zi);
+    zi += zi; // 2 * zr * zi
+    zi += ci;
+    zr = zr2 - zi2 + cr;
+  }
+  return MAX_ITER;
+}
+
+// Blue -> cyan -> green -> yellow -> red gradient (32 steps).
+// Four segments of SEGMENT_LEN, each interpolating one channel 0->MAX or
+// MAX->0.
+struct PaletteData {
+  static constexpr uint8_t SEGMENT_LEN = 8;    // iterations per color segment
+  static constexpr uint8_t MAX_INTENSITY = 15; // 4-bit palette channel max
+
+  uint8_t r[MAX_ITER + 1]{}, g[MAX_ITER + 1]{}, b[MAX_ITER + 1]{};
+
+  // Palette register uses reversed-nybble encoding: replicate
+  // 4-bit intensity into both nybbles for full brightness.
+  static constexpr uint8_t nyb(uint8_t n) { return (n << 4) | n; }
+
+  constexpr PaletteData() {
+    for (uint8_t i = 0; i < MAX_ITER; ++i) {
+      // Interpolate 0 -> MAX_INTENSITY over each segment
+      const uint8_t v =
+          (i & (SEGMENT_LEN - 1)) * MAX_INTENSITY / (SEGMENT_LEN - 1);
+      uint8_t rv = 0, gv = 0, bv = 0;
+      if (i < SEGMENT_LEN) {
+        gv = v;
+        bv = MAX_INTENSITY;
+      } else if (i < SEGMENT_LEN * 2) {
+        gv = MAX_INTENSITY;
+        bv = MAX_INTENSITY - v;
+      } else if (i < SEGMENT_LEN * 3) {
+        rv = v;
+        gv = MAX_INTENSITY;
+      } else {
+        rv = MAX_INTENSITY;
+        gv = MAX_INTENSITY - v;
+      }
+      r[i + 1] = nyb(rv);
+      g[i + 1] = nyb(gv);
+      b[i + 1] = nyb(bv);
+    }
+  }
+};
+
+static constexpr PaletteData palette{};
+
+static void setup_palette() {
+  for (uint8_t i = 0; i <= MAX_ITER; ++i) {
+    PALETTE.red[i] = palette.r[i];
+    PALETTE.green[i] = palette.g[i];
+    PALETTE.blue[i] = palette.b[i];
+  }
+}
+
+static void setup_vic() {
+  constexpr uint8_t VICIV_KEY1 = 0x47; // VIC-IV unlock knock sequence
+  constexpr uint8_t VICIV_KEY2 = 0x53;
+  constexpr uint8_t CPU_DDR_40MHZ = 65; // POKE 0,65 for full speed
+  constexpr uint8_t CHR16_BYTES_PER_CHAR = 2;
+
+  // Prevent KERNAL IRQ handler from corrupting VIC-IV register state.
+  asm volatile("sei");
+
+  // Unlock VIC-IV registers (knock sequence)
+  VICIV.key = VICIV_KEY1;
+  VICIV.key = VICIV_KEY2;
+
+  // Disable VIC-II hot registers so we can program VIC-IV directly
+  VICIV.sdbdrwd_msb &= ~VIC4_HOTREG_MASK;
+
+  // 40 MHz: POKE 0,65 sets full speed via CPU port DDR.
+  // VIC3_FAST alone only gives 3.5 MHz (C65 speed).
+  CPU_PORTDDR = CPU_DDR_40MHZ;
+
+  // Extended attributes (required for FCM), 40-column
+  VICIV.ctrlb = (VICIV.ctrlb | VIC3_FAST_MASK | VIC3_ATTR_MASK) &
+                ~(VIC3_H640_MASK | VIC3_V400_MASK);
+
+  // FCM: 16-bit character indices + full color for chars > $FF.
+  // FCLRHI without FCLRLO means only tiles with index > 255 use
+  // full-color mode — our tile indices start at 4096, so all qualify.
+  VICIV.ctrlc =
+      (VICIV.ctrlc & ~VIC4_FCLRLO_MASK) | VIC4_CHR16_MASK | VIC4_FCLRHI_MASK;
+
+  // Reuse KERNAL's default screen area — avoids relocating 2KB of RAM.
+  VICIV.scrnptr_lsb = 0x00;
+  VICIV.scrnptr_msb = 0x08;
+  VICIV.scrnptr_bnk = 0x00;
+  VICIV.scrnptr_mb = 0x00;
+
+  // Character data base at 0 — tile index N maps to address N*64
+  VICIV.charptr_lsb = 0x00;
+  VICIV.charptr_msb = 0x00;
+  VICIV.charptr_bnk = 0x00;
+
+  // 80 bytes per screen row (2 bytes per char in CHR16 mode)
+  VICIV.linestep = CELL_COLS * CHR16_BYTES_PER_CHAR;
+  VICIV.chrcount = CELL_COLS;
+  VICIV.disp_rows = CELL_ROWS;
+
+  // FCM is a text-mode extension — BMM must be off.
+  // Preserve raster MSB (0xC0), set DEN | RSEL | YSCROLL=3 (0x1B)
+  VICIV.ctrl1 = (VICIV.ctrl1 & 0xC0) | 0x1B;
+  // Preserve unused high bits (0xE0), set CSEL (0x08)
+  VICIV.ctrl2 = (VICIV.ctrl2 & 0xE0) | 0x08;
+
+  VICIV.bordercol = 0;
+  VICIV.screencol = 0;
+
+  // Use palette RAM for colors 0-15 (16+ always use palette RAM)
+  VICIV.ctrla |= VIC3_PAL_MASK;
+}
+
+static void setup_screen() {
+  constexpr uint16_t NUM_CELLS = CELL_COLS * CELL_ROWS;
+  constexpr uint16_t TILE_BASE = 0x1000;
+  constexpr uint16_t COLOR_RAM_ADDR = 0xD800;
+  auto *const SCREEN16 = reinterpret_cast<volatile uint16_t *>(&DEFAULT_SCREEN);
+  auto *const COLOR_RAM = reinterpret_cast<volatile uint8_t *>(COLOR_RAM_ADDR);
+
+  setup_palette();
+
+  // Each screen cell maps to a unique tile in the $40000 graphics area.
+  for (uint16_t i = 0; i < NUM_CELLS; ++i)
+    SCREEN16[i] = TILE_BASE + i;
+
+  // Neutral color RAM prevents unwanted FCM attributes (flips, alpha).
+  for (uint16_t i = 0; i < NUM_CELLS; ++i)
+    COLOR_RAM[i] = 0;
+
+  // Zero the graphics area so partially-rendered rows display as black.
+  const auto dma = make_dma_fill(GFX_ADDR, 0, NUM_CELLS * TILE_BYTES);
+  trigger_dma(dma);
+}
+
+// Render fractal one tile row at a time, DMA-copying each
+// completed row to graphics memory at $40000+.
+static void render_fractal() {
+  constexpr uint16_t SCREEN_COLS = 320;
+  constexpr uint16_t SCREEN_ROWS = 200;
+
+  // View window: real [-2.0, 0.6], imag [-1.0, 1.0]
+  constexpr fix16 RE_MIN = -2 * FP_ONE;
+  constexpr fix16 RE_MAX = static_cast<fix16>(0.6 * FP_ONE);
+  constexpr fix16 IM_MIN = -1 * FP_ONE;
+  constexpr fix16 IM_MAX = 1 * FP_ONE;
+
+  constexpr fix16 RE_STEP = (RE_MAX - RE_MIN) / SCREEN_COLS;
+  constexpr fix16 IM_STEP = (IM_MAX - IM_MIN) / SCREEN_ROWS;
+
+  for (uint8_t cy = 0; cy < CELL_ROWS; ++cy) {
+    for (uint8_t cx = 0; cx < CELL_COLS; ++cx) {
+      const uint16_t tile_off = static_cast<uint16_t>(cx) * TILE_BYTES;
+
+      for (uint8_t py = 0; py < TILE_PIXELS; ++py) {
+        const uint16_t y = static_cast<uint16_t>(cy) * TILE_PIXELS + py;
+
+        for (uint8_t px = 0; px < TILE_PIXELS; ++px) {
+          const uint16_t x = static_cast<uint16_t>(cx) * TILE_PIXELS + px;
+
+          const fix16 cr = RE_MIN + static_cast<fix16>(x) * RE_STEP;
+          const fix16 ci = IM_MIN + static_cast<fix16>(y) * IM_STEP;
+
+          const uint8_t iter = mandelbrot(cr, ci);
+
+          tile_row_buf[tile_off + py * TILE_PIXELS + px] =
+              (iter >= MAX_ITER) ? 0 : static_cast<uint8_t>(iter + 1);
+        }
+      }
+    }
+
+    const auto dma = make_dma_copy(
+        static_cast<uint32_t>(reinterpret_cast<uintptr_t>(tile_row_buf)),
+        GFX_ADDR + static_cast<uint32_t>(cy) * TILE_ROW_BYTES, TILE_ROW_BYTES);
+    trigger_dma(dma);
+  }
+}
+
+int main() {
+  setup_vic();
+  setup_screen();
+  render_fractal();
+
+  while (true)
+    ;
+}

--- a/examples/mega65/plasma.cc
+++ b/examples/mega65/plasma.cc
@@ -3,49 +3,30 @@
 // See https://github.com/llvm-mos/llvm-mos-sdk/blob/main/LICENSE for license
 // information.
 
-/*
- * Simplistic character-mode plasma effect
- *
- * Inspired by cc65/samples/cbm
- * - 2001 by groepaz
- * - Cleanup and porting by Ullrich von Bassewitz
- * - 2023 Mega65/LLVM-MOS C++ adaptation by Mikael Lund aka Wombat
- */
+//
+// Character-mode plasma effect for MEGA65 (80-column)
+//
+// MEGA65 features used:
+//   - VIC-IV 80-column mode with custom charset
+//   - Palette RAM ($D100): 16-color rotating gradient
+//   - Enhanced DMA: copies color buffer to $0FF80000 color RAM
+//   - 3.5 MHz C65 speed mode
+//
+// Inspired by cc65/samples/cbm
+//   - 2001 by groepaz
+//   - Cleanup and porting by Ullrich von Bassewitz
+//   - 2023 Mega65/LLVM-MOS C++ adaptation by Mikael Lund aka Wombat
+//   - 2026 Colorized by Claude AI Opus 4.6 and Mikael Lund
 
 #include <array>
 #include <cstdint>
+#include <dma.hpp>
 #include <mega65.h>
 
-/*
- * Simple pseudo-random number generator
- * https://en.wikipedia.org/wiki/Xorshift
- */
-class RandomXORS {
-private:
-  uint32_t state = 7;
+using namespace mega65::dma;
 
-public:
-  inline uint8_t rand8() { return static_cast<uint8_t>(rand32() & 0xff); }
-  inline uint32_t rand32() {
-    state ^= state << 13;
-    state ^= state >> 17;
-    state ^= state << 5;
-    return state;
-  }
-};
-
-/*
- * Sets MEGA65 speed to 3.5 Mhz
- */
-void speed_mode3() {
-  VICIV.ctrlb |= VIC3_FAST_MASK;
-  VICIV.ctrlc &= ~VIC4_VFAST_MASK;
-}
-
-/*
- * Cyclic sine lookup table
- */
-constexpr uint8_t sine_table[UINT8_MAX + 1] = {
+// Cyclic sine lookup table
+static constexpr uint8_t sine_table[UINT8_MAX + 1] = {
     0x80, 0x7d, 0x7a, 0x77, 0x74, 0x70, 0x6d, 0x6a, 0x67, 0x64, 0x61, 0x5e,
     0x5b, 0x58, 0x55, 0x52, 0x4f, 0x4d, 0x4a, 0x47, 0x44, 0x41, 0x3f, 0x3c,
     0x39, 0x37, 0x34, 0x32, 0x2f, 0x2d, 0x2b, 0x28, 0x26, 0x24, 0x22, 0x20,
@@ -69,56 +50,112 @@ constexpr uint8_t sine_table[UINT8_MAX + 1] = {
     0xb1, 0xae, 0xab, 0xa8, 0xa5, 0xa2, 0x9f, 0x9c, 0x99, 0x96, 0x93, 0x90,
     0x8c, 0x89, 0x86, 0x83};
 
-/*
- * Generate charset with 8 * 256 characters at given address
- */
-void make_charset(uint16_t charset_address, RandomXORS &rng) {
-  /*
-   * Lambda function to generate a single 8x8 pixels pattern
-   */
-  auto make_char = [&](const uint8_t sine) {
-    uint8_t pattern = 0;
-    constexpr uint8_t bits[8] = {1, 2, 4, 8, 16, 32, 64, 128};
-    for (const auto bit : bits) {
-      if (rng.rand8() > sine) {
-        pattern |= bit;
-      }
-    }
-    return pattern;
-  };
+static constexpr uint8_t NUM_COLORS = 16;
 
+// Sets MEGA65 speed to 3.5 Mhz
+static void speed_mode3() {
+  CPU_PORTDDR &= ~1;             // clear 40 MHz override
+  VICIV.ctrlb |= VIC3_FAST_MASK; // 3.5 MHz (C65 speed)
+}
+
+// Two-step VBlank sync: first ensure we're in the visible area,
+// then wait for the next VBlank edge. This avoids the false-pass
+// that occurs when the previous frame finishes during VBlank.
+static void wait_vblank() {
+  constexpr uint8_t RASTER_MSB = 0x80; // bit 7 of ctrl1: raster line >= 256
+  while (VICIV.ctrl1 & RASTER_MSB)
+    ;
+  while (!(VICIV.ctrl1 & RASTER_MSB))
+    ;
+}
+
+// Circular dithering matrix (values 0-63, 64=never lit). Pixels fill outward
+// from center as growing dots; maximum fill is an inscribed circle with corners
+// always empty. Quadrant-alternating tie-break prevents ring artifacts.
+// clang-format off
+static constexpr uint8_t circle8[8][8] = {
+    {64, 64, 54, 40, 47, 59, 64, 64},
+    {64, 52, 30, 20, 25, 35, 44, 64},
+    {62, 37, 15,  5, 10, 17, 32, 57},
+    {49, 27, 12,  0,  2,  7, 22, 42},
+    {43, 23,  9,  4,  1, 14, 28, 51},
+    {58, 33, 19, 11,  6, 16, 38, 63},
+    {64, 46, 36, 26, 21, 31, 53, 64},
+    {64, 64, 61, 48, 41, 56, 64, 64}
+};
+// clang-format on
+
+// Generate charset with 256 circular-dithered characters at given address.
+// Each character's fill density matches its sine_table entry, with pixels
+// filling outward from center to form smooth circular gradients.
+static void make_charset(const uint16_t charset_address) {
   auto charset = reinterpret_cast<volatile uint8_t *>(charset_address);
   for (const auto sine : sine_table) {
-    for (int _i = 0; _i < 8; ++_i) {
-      *(charset++) = make_char(sine);
+    // Invert so low sine = bright; shift to match circle8 range (0-63)
+    const uint8_t threshold = (UINT8_MAX - sine) >> 2;
+    for (uint8_t py = 0; py < 8; ++py) {
+      uint8_t pattern = 0;
+      for (uint8_t px = 0; px < 8; ++px) {
+        if (circle8[py][px] < threshold)
+          pattern |= (128 >> px);
+      }
+      *(charset++) = pattern;
     }
   }
 }
 
-/*
- * Plasma class
- */
+// Plasma class
 template <size_t COLS, size_t ROWS> class Plasma {
 private:
+  // 16 shades of blue for smooth palette cycling.
+  struct PaletteGradient {
+    std::array<uint8_t, NUM_COLORS> r{}, g{}, b{};
+
+    // Palette register uses reversed-nybble encoding: replicate
+    // 4-bit intensity into both nybbles for full brightness.
+    static constexpr uint8_t nyb(uint8_t n) { return (n << 4) | n; }
+
+    constexpr PaletteGradient() {
+      for (uint8_t i = 0; i < NUM_COLORS; ++i) {
+        r[i] = nyb(0);
+        g[i] = nyb(i / 4);           // subtle cyan tint at bright end
+        b[i] = nyb(i * 13 / 15 + 2); // dark navy (2) → bright blue (15)
+      }
+    }
+  };
+
+  static constexpr PaletteGradient gradient{};
+
   std::array<uint8_t, ROWS> ydata;
   std::array<uint8_t, COLS> xdata;
+  std::array<uint8_t, COLS * ROWS>
+      color_buf; // DMA-copied to color RAM each frame
   uint8_t x_cnt1 = 0;
   uint8_t x_cnt2 = 0;
   uint8_t y_cnt1 = 0;
   uint8_t y_cnt2 = 0;
+  uint8_t palette_offset = 0;
+
+  // Write rotated gradient to palette RAM entries 1-15.
+  // Entry 0 stays black (used by border and screen background).
+  void rotate_palette() {
+    for (uint8_t i = 1; i < NUM_COLORS; ++i) {
+      const uint8_t idx = (i + palette_offset) & (NUM_COLORS - 1);
+      PALETTE.red[i] = gradient.r[idx];
+      PALETTE.green[i] = gradient.g[idx];
+      PALETTE.blue[i] = gradient.b[idx];
+    }
+    ++palette_offset;
+  }
 
 public:
-  /*
-   * Generate and activate charset at given address
-   */
-  Plasma(const uint16_t charset_address, RandomXORS &rng) {
-    make_charset(charset_address, rng);
+  // Generate and activate charset at given address
+  Plasma(const uint16_t charset_address) {
+    make_charset(charset_address);
     VICIV.charptr = charset_address;
   }
 
-  /*
-   * Draw frame
-   */
+  // Draw frame
   inline void update() {
     auto i = y_cnt1;
     auto j = y_cnt2;
@@ -134,25 +171,35 @@ public:
       i += 3;
       j += 7;
     }
+    // Asymmetric increments create non-repeating interference patterns
     x_cnt1 += 2;
     x_cnt2 -= 3;
     y_cnt1 += 3;
     y_cnt2 -= 5;
 
+    rotate_palette(); // update palette while raster is in VBlank
     write_to_screen();
   }
 
-  /*
-   * Write summed buffers to screen memory
-   */
-  inline void write_to_screen() const {
+  // Write summed buffers to screen memory and update color RAM via DMA.
+  // Color RAM lives at $0FF80000 — outside the CPU's 16-bit address
+  // space — so we build a buffer and DMA copy it each frame.
+  inline void write_to_screen() {
     auto screen_ptr = reinterpret_cast<volatile uint8_t *>(&DEFAULT_SCREEN);
+    auto color_ptr = color_buf.data();
     for (const auto y : ydata) {
-#pragma unroll
+#pragma unroll 8 // reduce loop overhead without excessive code bloat
       for (const auto x : xdata) {
-        *(screen_ptr++) = y + x;
+        const uint8_t sum = y + x;
+        *(screen_ptr++) = sum; // character index into dithered charset
+        *(color_ptr++) = sum / NUM_COLORS; // map to palette entry 0-15
       }
     }
+    constexpr uint32_t COLOR_RAM_ADDR = 0x0FF80000UL; // 28-bit DMA address
+    static const auto dma = make_dma_copy(
+        static_cast<uint32_t>(reinterpret_cast<uintptr_t>(color_buf.data())),
+        COLOR_RAM_ADDR, COLS * ROWS);
+    trigger_dma(dma);
   }
 };
 
@@ -160,10 +207,32 @@ int main() {
   constexpr size_t COLS = 80;
   constexpr size_t ROWS = 25;
   constexpr uint16_t CHARSET_ADDRESS = 0x3000;
-  RandomXORS rng;
-  Plasma<COLS, ROWS> plasma(CHARSET_ADDRESS, rng);
+  Plasma<COLS, ROWS> plasma(CHARSET_ADDRESS);
+
+  constexpr uint8_t VICIV_KEY1 = 0x47; // VIC-IV unlock knock sequence
+  constexpr uint8_t VICIV_KEY2 = 0x53;
+
+  // Prevent KERNAL IRQ handler from relocking VIC-IV register state.
+  asm volatile("sei");
+
+  // Unlock VIC-IV registers for palette RAM access
+  VICIV.key = VICIV_KEY1;
+  VICIV.key = VICIV_KEY2;
+
+  // Use palette RAM for colors 0-15 (16+ always use palette RAM)
+  VICIV.ctrla |= VIC3_PAL_MASK;
+
+  // Black border and background — palette entry 0 is never rotated.
+  VICIV.bordercol = 0;
+  VICIV.screencol = 0;
+  PALETTE.red[0] = 0;
+  PALETTE.green[0] = 0;
+  PALETTE.blue[0] = 0;
+
   speed_mode3();
+
   while (true) {
+    wait_vblank();
     plasma.update();
   }
 }

--- a/examples/mega65/vector_logo.cc
+++ b/examples/mega65/vector_logo.cc
@@ -1,0 +1,377 @@
+// Copyright 2026 LLVM-MOS Project
+// Licensed under the Apache License, Version 2.0 with LLVM Exceptions.
+// See https://github.com/llvm-mos/llvm-mos-sdk/blob/main/LICENSE for license
+// information.
+//
+// Rotating vector-line "LLVM-MOS" logo for MEGA65
+//
+// Renders the text "LLVM-MOS" as wireframe line segments on a 320x200
+// hires bitmap, tumbling on all three axes with breathing zoom.
+//
+// MEGA65 features used:
+//   - C64-compatible Bit Map Mode (BMM): 320x200, 1 bit/pixel
+//   - Hardware math accelerator ($D768): 32x32 multiply for fixed-point
+//     rotation (sin/cos applied to each vertex per frame)
+//   - Enhanced DMA controller: fast 8KB bitmap clear each frame
+//   - VIC-IV extended screen/char pointers: places bitmap in BSS
+//     (avoids CIA2 bank tricks)
+//   - 3.5 MHz C65 speed mode
+
+#include <cstdint>
+#include <dma.hpp>
+#include <mega65.h>
+
+using namespace mega65::dma;
+
+// 8.8 fixed-point arithmetic
+using fix16 = int16_t;
+
+static constexpr uint16_t SCREEN_W = 320;
+static constexpr uint16_t SCREEN_H = 200;
+static constexpr uint8_t CELL_COLS = 40;
+static constexpr uint8_t CELL_ROWS = 25;
+static constexpr uint16_t SCREEN_RAM_SIZE =
+    CELL_COLS * CELL_ROWS; // fg/bg color nybbles per 8x8 cell
+static constexpr uint16_t CELL_ROW_BYTES = CELL_COLS * 8;
+static constexpr uint16_t BITMAP_SIZE = CELL_ROW_BYTES * CELL_ROWS;
+static constexpr uint16_t BITMAP_ALIGN = 8192;
+
+// Compile-time sine table (256 entries, 8.8 fixed-point, one full period)
+struct SineTable {
+  fix16 v[256]{};
+  constexpr SineTable() {
+    // Quarter-wave with double-precision Taylor (7th order Horner form),
+    // reflected to build all four quadrants. Double is fine here since
+    // this runs entirely at compile time.
+    constexpr double PI = 3.14159265358979323846;
+    for (int i = 0; i <= 64; ++i) {
+      double a = i * (PI / 2.0) / 64.0;
+      double a2 = a * a;
+      // sin(a) ~ a(1 - a^2/6(1 - a^2/20(1 - a^2/42)))
+      double s = a * (1.0 - a2 / 6.0 * (1.0 - a2 / 20.0 * (1.0 - a2 / 42.0)));
+      auto val = static_cast<fix16>(s * 256.0 + 0.5); // round to 8.8
+      if (val > 256)
+        val = 256;
+      v[i] = val;                 // quadrant I
+      v[128 - i] = val;           // quadrant II
+      v[128 + i] = -val;          // quadrant III
+      v[(256 - i) & 0xFF] = -val; // quadrant IV
+    }
+  }
+};
+
+static constexpr SineTable sin_tbl{};
+static constexpr fix16 sin8(uint8_t angle) { return sin_tbl.v[angle]; }
+static constexpr fix16 cos8(uint8_t angle) {
+  return sin_tbl.v[(angle + 64) & 0xFF];
+}
+
+// Logo geometry: "LLVM-MOS" as vertices + segments
+struct Vertex {
+  int8_t x, y;
+};
+struct Segment {
+  uint8_t v0, v1;
+};
+
+// NOLINTBEGIN
+// clang-format off
+
+// Each letter defined with vertices centered around a local origin,
+// placed side-by-side with spacing. Total span: x in [-57,57], y in [-8,8].
+static constexpr Vertex vertices[] = {
+  // L (x offset -54)
+  {-54,  -8}, {-54,   8}, {-46,   8},
+  // L (x offset -42)
+  {-42,  -8}, {-42,   8}, {-34,   8},
+  // V (x offset -28)
+  {-32,  -8}, {-28,   8}, {-24,  -8},
+  // M (x offset -17)
+  {-20,   8}, {-20,  -8}, {-14,   0}, {-8,  -8}, {-8,   8},
+  // - (x offset -2)
+  { -4,   0}, {  4,   0},
+  // M (x offset 11)
+  {  6,   8}, {  6,  -8}, { 12,   0}, { 18, -8}, { 18,  8},
+  // O (x offset 25)
+  { 22,  -8}, { 32,  -8}, { 32,   8}, { 22,   8},
+  // S (x offset 40)
+  { 46,  -8}, { 36,  -8}, { 36,   0}, { 46,   0}, { 46,   8}, { 36,   8},
+};
+
+static constexpr Segment segments[] = {
+  {0, 1}, {1, 2},                             // L
+  {3, 4}, {4, 5},                             // L
+  {6, 7}, {7, 8},                             // V
+  {9, 10}, {10, 11}, {11, 12}, {12, 13},      // M
+  {14, 15},                                   // -
+  {16, 17}, {17, 18}, {18, 19}, {19, 20},     // M
+  {21, 22}, {22, 23}, {23, 24}, {24, 21},     // O
+  {25, 26}, {26, 27}, {27, 28}, {28, 29}, {29, 30}, // S
+};
+
+// clang-format on
+// NOLINTEND
+
+// BMM rounds charptr down to 8KB boundary, so alignment is required.
+static uint8_t bitmap[BITMAP_SIZE] __attribute__((aligned(BITMAP_ALIGN)));
+
+// Screen RAM: each cell's nybbles set fg/bg color for its 8x8 block.
+static uint8_t screen_ram[SCREEN_RAM_SIZE];
+
+// Byte offset within bitmap for the leftmost pixel of each row.
+// BMM uses the VIC-II interleaved layout: 8 consecutive bytes per 8x8 cell,
+// cells arranged left-to-right then top-to-bottom (320 bytes per cell row).
+struct RowTable {
+  uint16_t v[SCREEN_H]{};
+  constexpr RowTable() {
+    for (uint16_t y = 0; y < SCREEN_H; ++y)
+      v[y] = (y >> 3) * CELL_ROW_BYTES + (y & 7);
+  }
+};
+
+static inline void plot_pixel(uint16_t x, uint16_t y) {
+  static constexpr RowTable row_addr{};
+  static constexpr uint8_t bit_mask[8] = {0x80, 0x40, 0x20, 0x10,
+                                          0x08, 0x04, 0x02, 0x01};
+  // Unsigned comparison catches negative values (they wrap to large positive)
+  if (x >= SCREEN_W || y >= SCREEN_H)
+    return;
+  bitmap[row_addr.v[y] + (x & ~7)] |= bit_mask[x & 7];
+}
+
+// Bresenham line drawing: integer-only, X-major or Y-major branch
+static void draw_line(int16_t x0, int16_t y0, int16_t x1, int16_t y1) {
+  int16_t dx = x1 - x0;
+  int16_t dy = y1 - y0;
+  int16_t sx = 1, sy = 1;
+
+  if (dx < 0) {
+    dx = -dx;
+    sx = -1;
+  }
+  if (dy < 0) {
+    dy = -dy;
+    sy = -1;
+  }
+
+  if (dx >= dy) {
+    int16_t err = dx >> 1;
+    for (int16_t i = 0; i <= dx; ++i) {
+      plot_pixel(static_cast<uint16_t>(x0), static_cast<uint16_t>(y0));
+      err -= dy;
+      if (err < 0) {
+        y0 += sy;
+        err += dx;
+      }
+      x0 += sx;
+    }
+  } else {
+    int16_t err = dy >> 1;
+    for (int16_t i = 0; i <= dy; ++i) {
+      plot_pixel(static_cast<uint16_t>(x0), static_cast<uint16_t>(y0));
+      err -= dx;
+      if (err < 0) {
+        x0 += sx;
+        err += dy;
+      }
+      y0 += sy;
+    }
+  }
+}
+
+// Hardware math accelerator
+//
+// The MEGA65 multiplier is combinational: the 64-bit product updates
+// as soon as both 32-bit inputs are written. We split fp_mul into
+// set/read helpers so the vertex loop can reuse whichever input
+// register hasn't changed between consecutive multiplies.
+static inline void fp_set_a(fix16 v) {
+  MATH.multina32 = static_cast<int32_t>(v);
+}
+
+static inline void fp_set_b(fix16 v) {
+  MATH.multinb32 = static_cast<int32_t>(v);
+}
+
+static inline fix16 fp_result() {
+  asm volatile("" ::: "memory");
+  return static_cast<fix16>(static_cast<int32_t>(MATH.multout32) >> 8);
+}
+
+static inline fix16 fp_mul(fix16 a, fix16 b) {
+  fp_set_a(a);
+  fp_set_b(b);
+  return fp_result();
+}
+
+// VIC-IV setup for C64-compatible hires bitmap mode
+static void setup_vic() {
+  constexpr uint8_t VICIV_KEY1 = 0x47; // VIC-IV unlock knock sequence
+  constexpr uint8_t VICIV_KEY2 = 0x53;
+  constexpr uint8_t CELL_COLOR =
+      0x86; // upper nybble = fg (orange), lower = bg (blue)
+
+  asm volatile("sei");
+
+  // Unlock VIC-IV registers
+  VICIV.key = VICIV_KEY1;
+  VICIV.key = VICIV_KEY2;
+
+  // Disable hot registers for direct VIC-IV programming
+  VICIV.sdbdrwd_msb &= ~VIC4_HOTREG_MASK;
+
+  // 3.5 MHz C65 speed (no 40 MHz override via CPU_PORTDDR),
+  // and disable VIC-III extended modes that would interfere
+  CPU_PORTDDR &= ~1;
+  VICIV.ctrlb =
+      (VICIV.ctrlb | VIC3_FAST_MASK) & ~(VIC3_H640_MASK | VIC3_V400_MASK);
+
+  // Point screen RAM to our array via extended pointers
+  auto scrn = reinterpret_cast<uintptr_t>(screen_ram);
+  VICIV.scrnptr_lsb = scrn & 0xFF;
+  VICIV.scrnptr_msb = (scrn >> 8) & 0xFF;
+  VICIV.scrnptr_bnk = 0x00;
+  VICIV.scrnptr_mb = 0x00;
+
+  // Point character/bitmap data to our aligned bitmap array
+  auto bm = reinterpret_cast<uintptr_t>(bitmap);
+  VICIV.charptr_lsb = bm & 0xFF;
+  VICIV.charptr_msb = (bm >> 8) & 0xFF;
+  VICIV.charptr_bnk = 0x00;
+
+  // 40-column, 25-row screen geometry (320x200 in BMM)
+  VICIV.linestep = CELL_COLS;
+  VICIV.chrcount = CELL_COLS;
+  VICIV.disp_rows = CELL_ROWS;
+
+  // Enable bitmap mode: BMM=1, DEN=1, RSEL=1, YSCROLL=3
+  VICIV.ctrl1 = 0x3B;
+  // Hires (not multicolor): CSEL=1, XSCROLL=0
+  VICIV.ctrl2 = 0x08;
+  // No FCM features
+  VICIV.ctrlc &= ~(VIC4_CHR16_MASK | VIC4_FCLRHI_MASK | VIC4_FCLRLO_MASK);
+
+  VICIV.bordercol = COLOR_BLUE;
+  VICIV.screencol = COLOR_BLUE;
+
+  for (auto &cell : screen_ram)
+    cell = CELL_COLOR;
+}
+
+// Two-step VBlank sync: wait for visible area, then wait for VBlank edge.
+// Avoids false-pass when the previous frame finishes during VBlank.
+static void wait_vblank() {
+  constexpr uint8_t RASTER_MSB = 0x80;
+  while (VICIV.ctrl1 & RASTER_MSB)
+    ;
+  while (!(VICIV.ctrl1 & RASTER_MSB))
+    ;
+}
+
+static constexpr auto NUM_VERTS = sizeof(vertices) / sizeof(vertices[0]);
+static int16_t screen_x[NUM_VERTS];
+static int16_t screen_y[NUM_VERTS];
+
+// Rotate, scale, and project all vertices to screen coordinates.
+// Multiply ordering minimizes 32-bit MMIO writes by reusing whichever
+// hardware math input register already holds the correct value.
+static void transform_vertices(uint8_t spin, uint8_t tilt, uint8_t yaw,
+                               fix16 scale) {
+  constexpr fix16 FP_ONE = 256;
+  const fix16 ss = sin8(spin);
+  const fix16 cs = cos8(spin);
+  const fix16 ct = cos8(tilt);
+  const fix16 cy = cos8(yaw);
+
+  for (size_t i = 0; i < NUM_VERTS; ++i) {
+    const fix16 vx = static_cast<fix16>(vertices[i].x) * FP_ONE;
+    const fix16 vy = static_cast<fix16>(vertices[i].y) * FP_ONE;
+
+    // Tilt (X-axis): foreshorten Y by cos(tilt)
+    fp_set_a(vy);
+    fp_set_b(ct);
+    const fix16 vy_t = fp_result();
+
+    // Spin components of vy_t
+    fp_set_a(vy_t);
+    fp_set_b(cs);
+    const fix16 vy_t_cs = fp_result();
+    fp_set_b(ss);
+    const fix16 vy_t_ss = fp_result();
+
+    // Yaw (Y-axis): foreshorten X by cos(yaw)
+    fp_set_a(vx);
+    fp_set_b(cy);
+    const fix16 vx_y = fp_result();
+
+    // Spin components of vx_y
+    fp_set_a(vx_y);
+    fp_set_b(ss);
+    const fix16 vx_y_ss = fp_result();
+    fp_set_b(cs);
+    const fix16 vx_y_cs = fp_result();
+
+    // Combine spin rotation and scale to screen center
+    const fix16 rx = vx_y_cs - vy_t_ss;
+    const fix16 ry = vx_y_ss + vy_t_cs;
+
+    fp_set_a(rx);
+    fp_set_b(scale);
+    screen_x[i] = (fp_result() >> 8) + (SCREEN_W / 2);
+
+    fp_set_a(ry); // B=scale reused
+    screen_y[i] = (fp_result() >> 8) + (SCREEN_H / 2);
+  }
+}
+
+static void draw_segments() {
+  for (const auto &seg : segments)
+    draw_line(screen_x[seg.v0], screen_y[seg.v0], screen_x[seg.v1],
+              screen_y[seg.v1]);
+}
+
+static void clear_bitmap() {
+  static const auto dma =
+      make_dma_fill(static_cast<uint32_t>(reinterpret_cast<uintptr_t>(bitmap)),
+                    0, BITMAP_SIZE);
+  trigger_dma(dma);
+}
+
+int main() {
+  setup_vic();
+
+  // Scale factor: 540/256 ~ 2.1x in 8.8 fixed-point, fills ~75% of screen width
+  constexpr fix16 SCALE = 540;
+  // Breathing zoom amplitude (8.8), scale oscillates +/-BREATH_AMP around SCALE
+  constexpr fix16 BREATH_AMP = 70;
+
+  // 8.8 fixed-point accumulators: high byte = angle, low byte = fraction.
+  // Coprime numerators ensure a long non-repeating tumble cycle.
+  uint16_t spin_acc = 0;   // Z-axis: screen-plane spin
+  uint16_t tilt_acc = 0;   // X-axis: around the logo's length axis
+  uint16_t yaw_acc = 0;    // Y-axis: around the logo's height axis
+  uint16_t breath_acc = 0; // breathing zoom oscillator
+
+  while (true) {
+    wait_vblank();
+    clear_bitmap();
+
+    const uint8_t spin = spin_acc >> 8;
+    const uint8_t tilt = tilt_acc >> 8;
+    const uint8_t yaw = yaw_acc >> 8;
+    const uint8_t breath = breath_acc >> 8;
+
+    // Breathing zoom: oscillate scale +/-BREATH_AMP around the base
+    const fix16 scale = SCALE + fp_mul(sin8(breath), BREATH_AMP);
+
+    transform_vertices(spin, tilt, yaw, scale);
+    draw_segments();
+
+    // Fractional increments: coprime numerators over 256
+    // Full rotation periods: ~9s, ~12s, ~7s, ~16s at 50 fps
+    spin_acc += 139;
+    tilt_acc += 107;
+    yaw_acc += 181;
+    breath_acc += 79;
+  }
+}


### PR DESCRIPTION
## Summary

- Enhance the **plasma** example with palette cycling colors (16-shade blue gradient rotated through palette RAM) and circular-dithered charset for smooth gradients
- Add **mandelbrot.cc**: 80-column fixed-point Mandelbrot with ordered-dither charset and C64 color palette
- Add **mandelbrot_fcm.cc**: 320×200 Full Color Mode Mandelbrot using VIC-IV FCM tiles, hardware math accelerator, and DMA to graphics memory at $40000+
- Add **vector_logo.cc**: real-time 3D rotating "LLVM-MOS" wireframe logo on hires bitmap with breathing zoom, running at 3.5 MHz
- Examples of `constexpr` for compile-time evaluation of constants and lookup tables.
- These examples were used to target new 65CE02 specific opcodes in codegen, see https://github.com/llvm-mos/llvm-mos/pull/550 and https://github.com/llvm-mos/llvm-mos/pull/547.

## MEGA65 features used

- VIC-IV Full Color Mode (CHR16 + FCLRHI)
- Hardware math accelerator ($D768) for fixed-point multiply
- Enhanced DMA controller for bitmap clear and memory copy
- VIC-IV extended screen/char pointers
- Palette RAM ($D100) for custom color gradients
- 80-column and 40-column text modes
- C64-compatible Bit Map Mode (BMM) via VIC-IV

## Tests

- [x] All four examples build with `cmake --build build --target mega65-examples`
- [x] Tested in xmega65 emulator: plasma, mandelbrot, mandelbrot_fcm, vector_logo

## AI Disclaimer

This was co-authored using [Claude Code](https://claude.com/claude-code) Opus 4.6. Humanly supervised and tested by @mlund in accordance with LLVM guidelines.