### PR TITLE
Add save-basic library for clean return to BASIC

### DIFF
--- a/mos-platform/commodore/CMakeLists.txt
+++ b/mos-platform/commodore/CMakeLists.txt
@@ -71,3 +71,5 @@ add_platform_library(commodore-c
 
 target_include_directories(commodore-c BEFORE PUBLIC .)
 target_link_libraries(commodore-c PRIVATE common-asminc)
+
+add_platform_object_file(commodore-save-basic save-basic.o save-basic.S)

--- a/mos-platform/commodore/commodore.ld
+++ b/mos-platform/commodore/commodore.ld
@@ -8,6 +8,9 @@
 /* Provide imaginary (zero page) registers in the BASIC area. */
 __rc0 = __basic_zp_start;
 INCLUDE imag-regs.ld
+
+/* Size of BASIC ZP region for save-basic library. */
+__basic_zp_size = __basic_zp_end - __basic_zp_start;
 /* No assertion - cx16 uses a non-contiguous imaginary register block larger than 32 bytes. */
 
 MEMORY { zp : ORIGIN = __rc31 + 1, LENGTH = __basic_zp_end - (__rc31 + 1) }

--- a/mos-platform/commodore/save-basic.S
+++ b/mos-platform/commodore/save-basic.S
@@ -1,0 +1,49 @@
+; Save/restore BASIC zero page state for clean return to BASIC interpreter.
+; Link with -l:save-basic.o to enable; overrides the default infinite-loop _Exit.
+;
+; Uses linker symbols __basic_zp_start and __basic_zp_size (computed in
+; commodore.ld from per-target __basic_zp_start/__basic_zp_end), so each
+; Commodore platform automatically saves its correct ZP range.
+
+; --- Save ZP + hardware stack pointer (before ROM unmap at .init.010) ---
+.section .init.005, "ax", @progbits
+  ; Save hardware stack pointer for _Exit to restore on return to BASIC.
+  tsx
+  stx __saved_basic_s
+
+  ; Save BASIC zero page (__basic_zp_start to __basic_zp_end - 1).
+  ldx #0
+.Lsave_zp:
+  lda __basic_zp_start,x
+  sta __saved_basic_zp,x
+  inx
+  cpx #mos16lo(__basic_zp_size)
+  bne .Lsave_zp
+
+; --- Restore ZP (before ROM restore and cli at .fini.990) ---
+.section .fini.989, "ax", @progbits
+  ldx #0
+.Lrestore_zp:
+  lda __saved_basic_zp,x
+  sta __basic_zp_start,x
+  inx
+  cpx #mos16lo(__basic_zp_size)
+  bne .Lrestore_zp
+
+; --- Override weak _Exit: restore hardware S and return to BASIC ---
+; Skips finalization (_fini) by design, matching C semantics for _Exit.
+; The normal exit() path runs _fini first (restoring ZP and ROMs), then
+; calls _Exit which only needs to restore the hardware stack pointer.
+.globl _Exit
+.section .text._Exit, "ax", @progbits
+_Exit:
+  ldx __saved_basic_s
+  txs
+  rts
+
+; --- Buffer in .noinit (no PRG file size cost) ---
+.section .noinit, "aw", @nobits
+__saved_basic_zp:
+  .fill 144               ; max ZP size across Commodore targets (VIC-20: $00-$8F)
+__saved_basic_s:
+  .fill 1


### PR DESCRIPTION
## Summary

This resolves a long-standing complaint from e.g. the MEGA65 community that we cannot return to BASIC. The change is currently fully optional, but perhaps better to make this the default behavior? I also investigated if this could be moved to `common`-level as suggested by @johnwbyrd in #343, but didn't find similarities as at the `commodore` level.

- Adds `save-basic.o` for Commodore targets that saves/restores zero page and hardware stack pointer, allowing programs to return to the `READY.` prompt instead of hanging in an infinite loop
- Link with `-l:save-basic.o` to opt in; the default exit-loop behavior is unchanged
- Uses per-target linker symbols (`__basic_zp_start`, `__basic_zp_end`) so a single shared object file works across all Commodore platforms (C64, MEGA65, C128, PET, VIC-20, CX16)

Addresses #343.

## How it works

1. `.init.005` (before ROM unmap): saves hardware S + ZP range to a RAM buffer
2. `.fini.989` (before ROM restore): restores ZP from the buffer
3. `_Exit` (strong, overrides weak exit-loop): restores hardware S and `rts` to BASIC

## Test plan

- [x] `llvm-objdump` confirms `_Exit` comes from save-basic, not exit-loop
- [x] Disassembly shows correct init/fini ordering and ZP size (`cpx #$8e` = 142 bytes)
- [x] Verified on xemu (MEGA65) and vice (C64, C128, PET, VIC20): prints message, returns to `READY.` prompt, BASIC remains functional. The VIC20 prg has a prior issue, but returns to READY prompt.
- [x] Without `-l:save-basic.o`: no regression, default infinite-loop behavior unchanged

## Disclaimer

Co-authored by Claude AI and reviewed and tested by @mlund in accordance with LLVM guidelines. Claude was here particularly useful for relentlessly hunting bugs and running emulator tests.