### PR TITLE
Add INTERMEDIATE platform kind; hide atari8-common wrappers

### DIFF
--- a/cmake/platform.cmake
+++ b/cmake/platform.cmake
@@ -29,7 +29,7 @@ endfunction()
 # present. A HOSTED platform supports the fragment of the C standard library
 # currently implemented. A COMPLETE platform cannot have any descendants.
 function(platform name)
-  cmake_parse_arguments(ARGS "COMPLETE;HOSTED" PARENT "" ${ARGN})
+  cmake_parse_arguments(ARGS "COMPLETE;HOSTED;INTERMEDIATE" PARENT "" ${ARGN})
 
   set(PLATFORM ${name})
   set(PLATFORM ${name} PARENT_SCOPE)
@@ -57,15 +57,23 @@ function(platform name)
     # --config flag is not set, argv0 of the form <config>-clang sets the implicit
     # config file as <config>.cfg. We leverage this convention using a set of
     # symlinks for each MOS platform.
-    foreach(suffix clang clang++ clang-cpp)
-      if(WIN32)
-        install(SCRIPT ${CMAKE_SOURCE_DIR}/cmake/install-clang-batch-file.cmake
-                CODE "install_clang_batch_file(${CMAKE_INSTALL_FULL_BINDIR} ${PLATFORM} ${suffix})")
-      else()
-        install(SCRIPT ${CMAKE_SOURCE_DIR}/cmake/install-clang-symlink.cmake
-                CODE "install_clang_symlink(${CMAKE_INSTALL_FULL_BINDIR} ${PLATFORM} ${suffix})")
-      endif()
-    endforeach()
+    #
+    # INTERMEDIATE platforms (e.g. atari8-common) do not get wrappers: they are
+    # shared layers consumed by other platforms, not user-facing build targets,
+    # and a user invoking mos-<intermediate>-clang gets a link that does not run
+    # on real hardware. The generated mos-<name>.cfg is still installed below so
+    # child platforms can @-include it.
+    if(NOT ARGS_INTERMEDIATE)
+      foreach(suffix clang clang++ clang-cpp)
+        if(WIN32)
+          install(SCRIPT ${CMAKE_SOURCE_DIR}/cmake/install-clang-batch-file.cmake
+                  CODE "install_clang_batch_file(${CMAKE_INSTALL_FULL_BINDIR} ${PLATFORM} ${suffix})")
+        else()
+          install(SCRIPT ${CMAKE_SOURCE_DIR}/cmake/install-clang-symlink.cmake
+                  CODE "install_clang_symlink(${CMAKE_INSTALL_FULL_BINDIR} ${PLATFORM} ${suffix})")
+        endif()
+      endforeach()
+    endif()
 
     if(COMPLETE)
       _add_platform_examples(${PLATFORM}-examples)

--- a/mos-platform/atari8-common/CMakeLists.txt
+++ b/mos-platform/atari8-common/CMakeLists.txt
@@ -1,4 +1,4 @@
-platform(atari8-common HOSTED PARENT common)
+platform(atari8-common HOSTED INTERMEDIATE PARENT common)
 
 if(NOT CMAKE_CROSSCOMPILING)
   return()


### PR DESCRIPTION
## What

Adds an `INTERMEDIATE` option to the `platform()` function in `cmake/platform.cmake`. When set, the platform's library/cfg are still built and installed, but the `mos-<name>-clang` / `clang++` / `clang-cpp` driver wrappers are not.

Applies it to `atari8-common`.

## Why

`atari8-common` exists only as a shared layer that `atari8-dos`, `atari8-cart-std`, `atari8-cart-megacart` and the `atari5200-*` carts chain through via `@mos-atari8-common.cfg`. There is no "atari8-common" machine, so the installed `mos-atari8-common-clang*` wrappers are misleading: a user invoking one gets a successful link that cannot run on real hardware.

## Scope

Install-side only. No library content changes. The generated `mos-atari8-common.cfg` is still installed so descendant `@`-includes resolve unchanged.

## Verification

- Built and installed against a fresh `/store0/opt/llvm-mos`.
- Post-install: `mos-atari8-common-clang*` absent; `mos-atari8-common.cfg` present.
- All atari8 descendant wrappers (`mos-atari8-dos-clang`, `mos-atari8-cart-std-clang`, ...) present and produce valid `.xex` / `.car` output.
- `test/atari8-dos` (2/2) and `test/atari8-cart-std` (7/7) pass.

## Follow-ups (not in this PR)

Other `HOSTED PARENT` platforms that look like analogous "shared layer" candidates and could plausibly become `INTERMEDIATE` in future PRs: `pce-common`, `nes-common`, `commodore`. Out of scope here.