### PR TITLE
[cx16] vpoke() reads the address from the wrong registers

### DIFF
--- a/mos-platform/cx16/vpoke.s
+++ b/mos-platform/cx16/vpoke.s
@@ -13,11 +13,10 @@
 .section .text.vpoke,"ax",@progbits
 vpoke:
         stz     VERA_CTRL              	; set DCSEL=0 to access ADDRSEL=0
-        ldy     __rc4
-        sty     VERA_ADDR_H
         ldy     __rc3
-        sty     VERA_ADDR_M
+        sty     VERA_ADDR_H
         ldy     __rc2
-        sty     VERA_ADDR_L
+        sty     VERA_ADDR_M
+        stx     VERA_ADDR_L
         sta     VERA_DATA0
         rts


### PR DESCRIPTION
`vpoke()` on the cx16 target reads the address from the wrong registers, so
every write lands at `addr >> 8`.

## The bug

`mos-platform/cx16/vpoke.s` contradicts its own header comment:

```asm
; void vpoke(unsigned char data, unsigned long addr);
; llvm-mos:                A                   X/rc2/3/4      <-- addr starts in X
vpoke:
        stz     VERA_CTRL
        ldy     __rc4                                          <-- addr byte 3
        sty     VERA_ADDR_H
        ldy     __rc3                                          <-- addr byte 2
        sty     VERA_ADDR_M
        ldy     __rc2                                          <-- addr byte 1
        sty     VERA_ADDR_L
        sta     VERA_DATA0
        rts
```

The comment has it right: `addr` occupies `X` (byte 0), `__rc2` (byte 1),
`__rc3` (byte 2), `__rc4` (byte 3). The code is off by one register — it
uses bytes 3, 2 and 1 where it wants 2, 1 and 0, and never reads `X` at
all. So the low byte is dropped, everything shifts down, and the write
lands at `addr >> 8`.

`vpeek.s` next door does it correctly, and shows the intended shape:

```asm
; unsigned char vpeek(unsigned long addr);
; llvm-mos:                     A/X/rc2/3
vpeek:
        stz     VERA_CTRL
        ldy     __rc2           ; byte 2 -> ADDR_H
        sty     VERA_ADDR_H
        stx     VERA_ADDR_M     ; byte 1 -> ADDR_M
        sta     VERA_ADDR_L     ; byte 0 -> ADDR_L
        ldx     #0
        lda     VERA_DATA0
        rts
```

Both are ports of cc65's originals, where the arguments arrive on a
software stack and have to be remapped for llvm-mos. `vpeek` was remapped
correctly; `vpoke` looks like it assumed `addr` began at `__rc2`, as it
would if `data` had not taken `A`.

## Reproducing

```c
#include <cx16.h>

int main(void) {
    vpoke(0xAB, 0x08000UL);
    vpoke(0xCD, 0x01234UL);
    // vpeek(0x08000) and vpeek(0x01234) read back whatever was there.
    // The bytes are at $00080 and $00012 instead.
    return 0;
}
```

Observed on x16emu with the r49 ROM, and confirmed by disassembling the
shipped `libc.a(vpoke.s.obj)` in v23.0.1 — the binary matches the source
above.

## Fix

```diff
 vpoke:
         stz     VERA_CTRL              	; set DCSEL=0 to access ADDRSEL=0
-        ldy     __rc4
-        sty     VERA_ADDR_H
         ldy     __rc3
-        sty     VERA_ADDR_M
+        sty     VERA_ADDR_H
         ldy     __rc2
-        sty     VERA_ADDR_L
+        sty     VERA_ADDR_M
+        stx     VERA_ADDR_L
         sta     VERA_DATA0
         rts
```

Reading the low byte straight out of `X` also makes the routine one
instruction shorter than it was.

Address byte 2 goes into `ADDR_H` unmasked, exactly as `vpeek` does it:
that carries the bank bit and leaves the increment field at zero, which is
what a single access wants.

## Verification

I hit this porting a VRAM-heavy library and worked around it locally by
overriding the symbol; the replacement is this patch's logic, and it is
covered by a test that writes `$A5` to `$12345` (nonzero low byte, bank
bit set), checks it arrives, and checks that `$00123` — where the current
code puts it — stays clean. That test passes with the fix and fails
without it.

One note for anyone else who has been bitten: poisoning the target VRAM
with `0x00` before a `vpoke()` hides this completely, because a write that
goes to the wrong address is invisible against zeroed VRAM. It only shows
up if you poison with a real value.
