### PR TITLE
[MEGA65] Correct Mega65 headers for VIC and ethernet controller

### DIFF
--- a/mos-platform/mega65/_45E100.h
+++ b/mos-platform/mega65/_45E100.h
@@ -33,9 +33,14 @@ struct __45E100 {
   uint8_t miim_phy_reg;
   uint16_t miimv;     //!< MIIM register value (offset 0x07)
   uint8_t macaddr[6]; //!< MAC address (offset 0x09)
+  /// Debug window (offset 0x0f). Reports whatever was last written to it;
+  /// 0 selects buffer identities, low two bits being the CPU's read buffer.
+  uint8_t debug;
 };
 #ifdef __cplusplus
-static_assert(sizeof(struct __45E100) == 15);
+static_assert(sizeof(struct __45E100) == 16);
+#else
+_Static_assert(sizeof(struct __45E100) == 16, "45E100 block is $D6E0-$D6EF");
 #endif
 
 /// 45E100 Fast Ethernet controller commands
@@ -65,50 +70,66 @@ enum
     : uint8_t
 #endif
 {
-  /** Write 0 to hold ethernet controller under reset */
+  /* ctrl1 ($D6E0) */
+  /** Write 0 to hold the controller under reset */
   ETH_RST_MASK = 0b00000001,
-  /** Write 0 to hold ethernet controller transmit sub-system under reset
-   */
+  /** Write 0 to hold the transmit sub-system under reset */
   ETH_TXRST_MASK = 0b00000010,
   /** Read ethernet RX bits currently on the wire */
   ETH_DRXD_MASK = 0b00000100,
   /** Read ethernet RX data valid (debug) */
   ETH_DRXDV_MASK = 0b00001000,
-  /** Allow remote keyboard input via magic ethernet frames */
+  /** Allow remote keyboard input via magic ethernet frames. Reads back as
+      the remote-control enable status. */
   ETH_KEYEN_MASK = 0b00010000,
-  /** Indicate if ethernet RX is blocked until RX buffers freed */
+  /** RX is blocked until receive buffers are freed */
   ETH_RXBLKD_MASK = 0b01000000,
-  /** Ethernet transmit side is idle, i.e., a packet can be sent. */
+  /** Transmit side is idle, i.e. a packet can be sent */
   ETH_TXIDLE_MASK = 0b10000000,
-  /** Number of free receive buffers */
+
+  /* ctrl2 ($D6E1) */
+  /** Number of free receive buffers. Read only; writing bit 1 is
+      ETH_RXROTATE_MASK instead. */
   ETH_RXBF_MASK = 0b00000110,
-  /** Enable streaming of CPU instruction stream or VIC-IV display on
-   * ethernet
-   */
+  /** Write to hand back the current receive buffer and present the next
+      frame. Edge triggered, so it takes a write with the bit clear followed
+      by one with it set. */
+  ETH_RXROTATE_MASK = 0b00000010,
+  /** Enable streaming of CPU instruction stream or VIC-IV display */
   ETH_STRM_MASK = 0b00001000,
-  /** Ethernet TX IRQ status */
+  /** Indicate if ethernet TX is idle */
   ETH_TXQ_MASK = 0b00010000,
-  /** Ethernet RX IRQ status */
+  /** Indicate if a received frame is waiting */
   ETH_RXQ_MASK = 0b00100000,
   /** Enable ethernet TX IRQ */
   ETH_TXQEN_MASK = 0b01000000,
   /** Enable ethernet RX IRQ */
   ETH_RXQEN_MASK = 0b10000000,
-  /** Ethernet disable promiscuous mode */
+
+  /* ctrl3 ($D6E5) */
+  /** Disable promiscuous mode. iomap.txt annotates this bit twice, as
+      "disable promiscuous mode" and as "enable filtering of unicast frames
+      if MAC address does not match", and annotates ETH_MCST_MASK as both the
+      multicast and the unicast enable. Which reading is right has not been
+      settled here; matching addresses in software avoids the question. */
   ETH_NOPROM_MASK = 0b00000001,
   /** Disable CRC check for received packets */
   ETH_NOCRC_MASK = 0b00000010,
-  /** Ethernet TX clock phase adjust */
+  /** TX clock phase, a two-bit field: use ETH_TXPH_SHIFT */
   ETH_TXPH_MASK = 0b00001100,
+  ETH_TXPH_SHIFT = 2,
   /** Accept broadcast frames */
   ETH_BCST_MASK = 0b00010000,
-  /** Accept multicast frames */
+  /** Accept multicast frames (see ETH_NOPROM_MASK) */
   ETH_MCST_MASK = 0b00100000,
-  /** Ethernet RX clock phase adjust */
+  /** RX clock phase, a two-bit field: use ETH_RXPH_SHIFT */
   ETH_RXPH_MASK = 0b11000000,
-  /** Ethernet MIIM register number */
+  ETH_RXPH_SHIFT = 6,
+
+  /* miim_phy_reg ($D6E6) */
+  /** MIIM register number */
   ETH_MIIMREG_MASK = 0b00011111,
-  /** Ethernet MIIM PHY number (use 0 for Nexys4, 1 for MEGA65 r1 PCBs) */
+  /** MIIM PHY number */
   ETH_MIIMPHY_MASK = 0b11100000
 };
 

--- a/mos-platform/mega65/_45E100.h
+++ b/mos-platform/mega65/_45E100.h
@@ -14,7 +14,8 @@ extern "C" {
 
 /// 45E100 Fast Ethernet controller
 ///
-/// Enabled by writing 0x53 and then 0x47 to VIC-IV register 0xD02F
+/// Map the controller's buffers over 0xD000-0xDFFF by writing
+/// VIC4_KEY_ETH_A then VIC4_KEY_ETH_B to VICIV.key.
 struct __45E100 {
   uint8_t ctrl1; //!< Control register 1 (offset 0x00)
   uint8_t ctrl2; //!< Control register 2 (offset 0x01)

--- a/mos-platform/mega65/_vic4.h
+++ b/mos-platform/mega65/_vic4.h
@@ -315,6 +315,22 @@ struct __vic4 {
 static_assert(sizeof(__vic4) == 0x80);
 #endif
 
+/// Values written to VICIV.key to choose which registers appear at
+/// 0xD000-0xDFFF. Write the two bytes of a pair in that order; any other
+/// value returns to VIC-II.
+enum
+#ifdef __clang__
+    : uint8_t
+#endif
+{
+  VIC4_KEY_VICIII_A = 0xa5, //!< ...then VIC4_KEY_VICIII_B for C65/VIC-III
+  VIC4_KEY_VICIII_B = 0x96,
+  VIC4_KEY_VICIV_A = 0x47, //!< ...then VIC4_KEY_VICIV_B for MEGA65/VIC-IV
+  VIC4_KEY_VICIV_B = 0x53,
+  VIC4_KEY_ETH_A = 0x45, //!< ...then VIC4_KEY_ETH_B for the 45E100 buffers
+  VIC4_KEY_ETH_B = 0x54,
+};
+
 /*
  * The following masks are auto-generated from iomap.txt.
  * See https://github.com/dansanderson/mega65-symbols


### PR DESCRIPTION
Two mega65 sdk header fixes found while writing a driver. Checked against the VHDL core for MEGA65.

#### `D02F` knocks

`$D02F` selects which registers appear at `$D000-$DFFF` and takes three two-byte sequences according to the MEGA65 core (`viciv.vhdl:2492-2510`): `$A5,$96` for VIC-III, `$47,$53` for VIC-IV, `$45,$54` for the 45E100 buffers. They had no names, so callers wrote bare numbers. Adds `VIC4_KEY_*`.

`_45E100.h` said the controller is "Enabled by writing 0x53 and then 0x47" — the VIC-IV sequence with its bytes reversed, and not what maps the ethernet buffers.

#### Ethernet 45E100 register header

- Masks did not say which register they belong to. 20 in flat enum, and the values repeat: `ETH_RST_MASK` and `ETH_NOPROM_MASK` are both `0b00000001`, in `$D6E0` and `$D6E5`. Now grouped per register.
- The size assertion never ran for C, being inside `#ifdef __cplusplus` — and C callers are the ones most likely to index past the struct. Also establishes that the unaligned `uint16_t miimv` at offset 7 gets no padding.
- `$D6EF` was outside the struct, so the debug window had no name.
- `ETH_RXBF_MASK` described only read. Writing bit 1 of `$D6E1` hands back the receive buffer and presents the next frame, edge-triggered (`ethernet.vhdl:1787`). Adds `ETH_RXROTATE_MASK`.
- `ETH_TXPH`/`ETH_RXPH` are two-bit fields, so ORing the mask sets both bits rather than a value. Adds the shifts.

Also logs that `iomap.txt` from the MEGA65 core annotates `$D6E5.0` as both "disable promiscuous mode" and "enable filtering of unicast frames if MAC address does not match", and `$D6E5.5` as both the multicast and the unicast enable.

Claude Opus 5 was used to check header correctness against the MEGA65 VHDL core files. @mlund reviewed and tested.