### PR TITLE
[MEGA65] SD card MMIO access

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,25 @@ if(NOT CMAKE_CROSSCOMPILING)
     PATHS /lib64/libretro ENV LIBRETRO_CORES_DIR)
   message(STATUS "Libretro MESEN core: ${LIBRETRO_MESEN_CORE}")
 
+  # Xemu ships as a macOS app bundle and is never on PATH, and a bundle
+  # outranks HINTS, so an XMEGA65_DIR override would be ignored in favour of
+  # whatever is installed. The bundle's binary is named in PATHS instead. A
+  # function scopes the setting; find_program's result is cached, so it still
+  # escapes.
+  function(find_xmega65)
+    set(CMAKE_FIND_APPBUNDLE NEVER)
+    find_program(XMEGA65_COMMAND
+      NAMES xmega65 xmega65.native xmega65.exe xemu-xmega65 xemu-xmega65.exe
+      HINTS ENV XMEGA65_DIR
+      PATHS "$ENV{HOME}/bin" /Applications/xmega65.app/Contents/MacOS)
+  endfunction()
+  find_xmega65()
+  message(STATUS "MEGA65 emulator (xmega65): ${XMEGA65_COMMAND}")
+
+  find_program(PYTHON3_COMMAND NAMES python3 python
+    HINTS ENV PYTHON_DIR)
+  message(STATUS "Python 3 interpreter: ${PYTHON3_COMMAND}")
+
   # Install toolchain and config file for users of find_package(llvm-mos-sdk).
   # CMake's find_package logic will discover
   # `$PATH/../lib/cmake/llvm-mos-sdk/llvm-mos-sdk-config.cmake` which in turn

--- a/mos-platform/commodore/cbm_kernal.inc
+++ b/mos-platform/commodore/cbm_kernal.inc
@@ -80,6 +80,26 @@
   SETBNK       = $FF68
 #endif
 
+#ifdef __MEGA65__
+  ; MEGA65 extended jump table
+  SAVEFL       = $FF3B
+  GETIO        = $FF41
+  GETLFS       = $FF44
+  SYSFLAGS     = $FF47
+  ADDKEY       = $FF4A
+  CLOSE_ALL    = $FF50
+  LKUPLA       = $FF5F
+  LKUPSA       = $FF62
+  SWAPPER      = $FF65
+  PFKEY        = $FF68
+  SETBNK       = $FF6B
+  JSRFAR       = $FF6E
+  JMPFAR       = $FF71
+  LDA_FAR      = $FF74
+  STA_FAR      = $FF77
+  CMP_FAR      = $FF7A
+#endif
+
 #if defined(__C128__) || defined(__CX16__)
   ; Extended jump table
   CLSALL       = $FF4A

--- a/mos-platform/mega65/CMakeLists.txt
+++ b/mos-platform/mega65/CMakeLists.txt
@@ -13,6 +13,7 @@ install(FILES
 TYPE INCLUDE)
 
 install(FILES link.ld TYPE LIB)
+install(PROGRAMS d81.py TYPE BIN)
 
 add_platform_library(mega65-crt0)
 merge_libraries(mega65-crt0
@@ -24,7 +25,50 @@ add_platform_object_file(mega65-basic-header basic-header.o basic-header.S)
 add_platform_object_file(mega65-unmap-basic unmap-basic.o unmap-basic.S)
 
 add_platform_library(mega65-c
+  cbm_k_cint.c
+  cbm_k_load.c
+  cbm_k_save.c
   filevars.s
   kernal.S
+  mega65_k_addkey.c
+  mega65_k_lda_far.c
+  mega65_k_sta_far.c
+  mega65_k_cmp_far.c
+  mega65_k_close_all.c
+  mega65_k_getio.c
+  mega65_k_getlfs.c
+  mega65_k_load.c
+  mega65_k_lkupla.c
+  mega65_k_lkupsa.c
+  mega65_k_plot.c
+  mega65_k_savefl.c
+  mega65_k_rdtim.c
+  mega65_k_scrorg.c
+  mega65_k_setbnk.c
+  mega65_k_setmsg.c
+  mega65_k_settim.c
+  mega65_k_swapper.c
+  mega65_k_sysflags.c
+  mega65_h_attach.c
+  mega65_h_dirio.c
+  mega65_h_drive.c
+  mega65_h_fileio.c
+  mega65_h_d81write_en.c
+  mega65_h_findfile.c
+  mega65_h_mkfile.c
+  mega65_h_loadfile.c
+  mega65_h_setname.c
+  mega65_h_setname_page.c
+  mega65_h_get_proc_desc.c
+  mega65_h_locate_freezeslot.c
+  mega65_h_unfreeze_from_slot.c
+  mega65_h_read_freeze_region_list.c
+  mega65_h_get_freeze_slot_count.c
+  mega65_h_writefile.c
+  mega65_h_getversion.c
+  mega65_h_geterrorcode.c
 )
-target_include_directories(mega65-c BEFORE PUBLIC .)
+target_compile_options(mega65-c PRIVATE -mcpu=mos45gs02)
+target_include_directories(mega65-c BEFORE PUBLIC .
+  ${CMAKE_CURRENT_SOURCE_DIR}/../c64
+  ${CMAKE_CURRENT_SOURCE_DIR}/../commodore)

--- a/mos-platform/mega65/CMakeLists.txt
+++ b/mos-platform/mega65/CMakeLists.txt
@@ -6,6 +6,7 @@ endif()
 install(FILES
     _45E100.h
     _dmagic.h
+    _sdcard.h
     _vic3.h
     _vic4.h
     dma.hpp

--- a/mos-platform/mega65/_45E100.h
+++ b/mos-platform/mega65/_45E100.h
@@ -33,9 +33,14 @@ struct __45E100 {
   uint8_t miim_phy_reg;
   uint16_t miimv;     //!< MIIM register value (offset 0x07)
   uint8_t macaddr[6]; //!< MAC address (offset 0x09)
+  /// Debug window (offset 0x0f). Reports whatever was last written to it;
+  /// 0 selects buffer identities, low two bits being the CPU's read buffer.
+  uint8_t debug;
 };
 #ifdef __cplusplus
-static_assert(sizeof(struct __45E100) == 15);
+static_assert(sizeof(struct __45E100) == 16);
+#else
+_Static_assert(sizeof(struct __45E100) == 16, "45E100 block is $D6E0-$D6EF");
 #endif
 
 /// 45E100 Fast Ethernet controller commands
@@ -65,50 +70,66 @@ enum
     : uint8_t
 #endif
 {
-  /** Write 0 to hold ethernet controller under reset */
+  /* ctrl1 ($D6E0) */
+  /** Write 0 to hold the controller under reset */
   ETH_RST_MASK = 0b00000001,
-  /** Write 0 to hold ethernet controller transmit sub-system under reset
-   */
+  /** Write 0 to hold the transmit sub-system under reset */
   ETH_TXRST_MASK = 0b00000010,
   /** Read ethernet RX bits currently on the wire */
   ETH_DRXD_MASK = 0b00000100,
   /** Read ethernet RX data valid (debug) */
   ETH_DRXDV_MASK = 0b00001000,
-  /** Allow remote keyboard input via magic ethernet frames */
+  /** Allow remote keyboard input via magic ethernet frames. Reads back as
+      the remote-control enable status. */
   ETH_KEYEN_MASK = 0b00010000,
-  /** Indicate if ethernet RX is blocked until RX buffers freed */
+  /** RX is blocked until receive buffers are freed */
   ETH_RXBLKD_MASK = 0b01000000,
-  /** Ethernet transmit side is idle, i.e., a packet can be sent. */
+  /** Transmit side is idle, i.e. a packet can be sent */
   ETH_TXIDLE_MASK = 0b10000000,
-  /** Number of free receive buffers */
+
+  /* ctrl2 ($D6E1) */
+  /** Number of free receive buffers. Read only; writing bit 1 is
+      ETH_RXROTATE_MASK instead. */
   ETH_RXBF_MASK = 0b00000110,
-  /** Enable streaming of CPU instruction stream or VIC-IV display on
-   * ethernet
-   */
+  /** Write to hand back the current receive buffer and present the next
+      frame. Edge triggered, so it takes a write with the bit clear followed
+      by one with it set. */
+  ETH_RXROTATE_MASK = 0b00000010,
+  /** Enable streaming of CPU instruction stream or VIC-IV display */
   ETH_STRM_MASK = 0b00001000,
-  /** Ethernet TX IRQ status */
+  /** Indicate if ethernet TX is idle */
   ETH_TXQ_MASK = 0b00010000,
-  /** Ethernet RX IRQ status */
+  /** Indicate if a received frame is waiting */
   ETH_RXQ_MASK = 0b00100000,
   /** Enable ethernet TX IRQ */
   ETH_TXQEN_MASK = 0b01000000,
   /** Enable ethernet RX IRQ */
   ETH_RXQEN_MASK = 0b10000000,
-  /** Ethernet disable promiscuous mode */
+
+  /* ctrl3 ($D6E5) */
+  /** Disable promiscuous mode. iomap.txt annotates this bit twice, as
+      "disable promiscuous mode" and as "enable filtering of unicast frames
+      if MAC address does not match", and annotates ETH_MCST_MASK as both the
+      multicast and the unicast enable. Which reading is right has not been
+      settled here; matching addresses in software avoids the question. */
   ETH_NOPROM_MASK = 0b00000001,
   /** Disable CRC check for received packets */
   ETH_NOCRC_MASK = 0b00000010,
-  /** Ethernet TX clock phase adjust */
+  /** TX clock phase, a two-bit field: use ETH_TXPH_SHIFT */
   ETH_TXPH_MASK = 0b00001100,
+  ETH_TXPH_SHIFT = 2,
   /** Accept broadcast frames */
   ETH_BCST_MASK = 0b00010000,
-  /** Accept multicast frames */
+  /** Accept multicast frames (see ETH_NOPROM_MASK) */
   ETH_MCST_MASK = 0b00100000,
-  /** Ethernet RX clock phase adjust */
+  /** RX clock phase, a two-bit field: use ETH_RXPH_SHIFT */
   ETH_RXPH_MASK = 0b11000000,
-  /** Ethernet MIIM register number */
+  ETH_RXPH_SHIFT = 6,
+
+  /* miim_phy_reg ($D6E6) */
+  /** MIIM register number */
   ETH_MIIMREG_MASK = 0b00011111,
-  /** Ethernet MIIM PHY number (use 0 for Nexys4, 1 for MEGA65 r1 PCBs) */
+  /** MIIM PHY number */
   ETH_MIIMPHY_MASK = 0b11100000
 };
 

--- a/mos-platform/mega65/_45E100.h
+++ b/mos-platform/mega65/_45E100.h
@@ -37,10 +37,12 @@ struct __45E100 {
   /// 0 selects buffer identities, low two bits being the CPU's read buffer.
   uint8_t debug;
 };
+#ifdef __mos__
 #ifdef __cplusplus
 static_assert(sizeof(struct __45E100) == 16);
 #else
 _Static_assert(sizeof(struct __45E100) == 16, "45E100 block is $D6E0-$D6EF");
+#endif
 #endif
 
 /// 45E100 Fast Ethernet controller commands

--- a/mos-platform/mega65/_45E100.h
+++ b/mos-platform/mega65/_45E100.h
@@ -14,7 +14,8 @@ extern "C" {
 
 /// 45E100 Fast Ethernet controller
 ///
-/// Enabled by writing 0x53 and then 0x47 to VIC-IV register 0xD02F
+/// Map the controller's buffers over 0xD000-0xDFFF by writing
+/// VIC4_KEY_ETH_A then VIC4_KEY_ETH_B to VICIV.key.
 struct __45E100 {
   uint8_t ctrl1; //!< Control register 1 (offset 0x00)
   uint8_t ctrl2; //!< Control register 2 (offset 0x01)

--- a/mos-platform/mega65/_dmagic.h
+++ b/mos-platform/mega65/_dmagic.h
@@ -6,10 +6,8 @@
 #ifndef _DMAGIC_H
 #define _DMAGIC_H
 
-#ifndef __cplusplus
 #include <stddef.h>
 #include <stdint.h>
-#endif
 
 /// DMA commands
 enum
@@ -121,7 +119,7 @@ struct DMAAudioChannel {
   };
 };
 
-#ifdef __cplusplus
+#if defined(__mos__) && defined(__cplusplus)
 static_assert(sizeof(DMAAudioChannel) == 0x10);
 #endif
 
@@ -183,7 +181,7 @@ struct DMAgicController {
   };
 };
 
-#ifdef __cplusplus
+#if defined(__mos__) && defined(__cplusplus)
 static_assert(sizeof(DMAgicController) == 0x60);
 #endif
 

--- a/mos-platform/mega65/_sdcard.h
+++ b/mos-platform/mega65/_sdcard.h
@@ -1,0 +1,193 @@
+// Copyright 2026 LLVM-MOS Project
+// Licensed under the Apache License, Version 2.0 with LLVM Exceptions.
+// See https://github.com/llvm-mos/llvm-mos-sdk/blob/main/LICENSE for license
+// information.
+
+#ifndef _SDCARD_H
+#define _SDCARD_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/// MEGA65 SD card controller
+///
+/// Needs the MEGA65 I/O personality, which VICIV.key selects; see _vic4.h.
+///
+/// Sector data does not pass through these registers. It lives in a 512-byte
+/// buffer, reached at 0xFFD6E00 by DMA or 32-bit addressing, or at 0xDE00 in
+/// the ordinary I/O window once SDCARD_MAP_BUFFER has put it there and colour
+/// RAM is elsewhere than 0xDC00.
+struct __sdcard {
+  union {
+    uint8_t command; //!< Command to the controller, SDCARD_* (offset 0x00)
+    uint8_t status;  //!< Controller status, SD_*_MASK (offset 0x00)
+  };
+  union {
+    /// Sector to read or write, low byte first (offset 0x01)
+    ///
+    /// Four independent latches, sampled only when a command is written, so
+    /// the order they are set in does not matter. Index with a uint8_t: an
+    /// int index costs a zero-page pointer instead of absolute addressing.
+    uint8_t sector[4];
+    uint32_t sector_number; //!< The same four registers as one number
+  };
+  uint8_t state; //!< (read only) controller state, for debugging (offset 0x05)
+  union {
+    uint8_t fill_value; //!< Byte written to a whole sector in fill mode (0x06)
+    uint8_t data_token; //!< (read only) the card's last data token (0x06)
+  };
+  uint8_t last_byte;   //!< (read only) most recent byte read (offset 0x07)
+  uint8_t f011_bufptr; //!< (read only) F011 buffer pointer, low byte (0x08)
+  uint8_t control;     //!< Buffer and drive control, SD_*_MASK (offset 0x09)
+};
+
+/// F011 floppy emulation: which disk image each drive uses, and where it is
+///
+/// Writable in hypervisor mode only, so an ordinary program's writes here are
+/// discarded without a word. The readable bits are not the writable ones
+/// either: image_type reads machine state and writes the two D64 flags.
+struct __sdfdc {
+  uint8_t image_type; //!< Machine state read, D64 flags written (offset 0x00)
+  uint8_t flags;      //!< Per-drive image flags, SDFDC_*_MASK (offset 0x01)
+  union {
+    uint8_t d0_start_sector[4]; //!< Drive 0 image's first sector (offset 0x02)
+    uint32_t d0_start;
+  };
+  union {
+    uint8_t d1_start_sector[4]; //!< Drive 1 image's first sector (offset 0x06)
+    uint32_t d1_start;
+  };
+};
+
+// On the target only. A host aligns the 32-bit members and pads the structs,
+// and code that includes <mega65.h> to test its arithmetic natively should
+// still compile. The sibling headers guard on __cplusplus instead, which does
+// not buy them that: a host C++ build fails on __45E100's assert as it stands.
+#ifdef __mos__
+#ifdef __cplusplus
+static_assert(sizeof(struct __sdcard) == 10);
+static_assert(sizeof(struct __sdfdc) == 10);
+#else
+_Static_assert(sizeof(struct __sdcard) == 10, "SD controller is $D680-$D689");
+_Static_assert(sizeof(struct __sdfdc) == 10, "F011 image state is $D68A-$D693");
+#endif
+#endif
+
+/// MEGA65 SD card controller commands
+///
+/// A reset is SDCARD_RESET_BEGIN then SDCARD_RESET_END, and it returns the
+/// card to byte addressing: one that answered SD_SDHC_MASK needs
+/// SDCARD_SDHC_MODE_ON again, or every sector number is taken as a byte
+/// offset and no transfer finishes.
+enum
+#ifdef __clang__
+    : uint8_t
+#endif
+{
+  SDCARD_RESET_BEGIN = 0x00,
+  SDCARD_RESET_END = 0x01,
+  SDCARD_READ_SECTOR = 0x02,
+  SDCARD_WRITE_SECTOR = 0x03,
+  SDCARD_WRITE_MULTI_FIRST = 0x04,
+  SDCARD_WRITE_MULTI_NEXT = 0x05,
+  SDCARD_WRITE_MULTI_LAST = 0x06,
+  SDCARD_FLUSH_CACHE = 0x0c,     /** Flush the card's own write cache */
+  SDCARD_SDHC_MODE_OFF = 0x40,   /** Address by byte */
+  SDCARD_SDHC_MODE_ON = 0x41,    /** Address by sector */
+  SDCARD_ERROR_CLEAR_OFF = 0x44, /** Stop clearing the error flags */
+  SDCARD_ERROR_CLEAR_ON = 0x45,  /** Clear the error flags */
+  /// Open the write gate for sector zero. A write needs a gate open, and
+  /// which one depends on the sector: this for sector zero, SDCARD_WRITE_GATE
+  /// for any other. Each lasts about a millisecond, and the wrong one leaves
+  /// the write refused with the error bits set -- which is what keeps a stray
+  /// write off a card's own boot sector.
+  SDCARD_WRITE_GATE_SECTOR0 = 0x4d,
+  SDCARD_WRITE_GATE = 0x57,       /** Write gate for any other sector */
+  SDCARD_MAP_BUFFER = 0x81,       /** Show the sector buffer at 0xDE00 */
+  SDCARD_UNMAP_BUFFER = 0x82,     /** Hide it again */
+  SDCARD_FILL_MODE_ON = 0x83,     /** Write fill_value instead of the buffer */
+  SDCARD_FILL_MODE_OFF = 0x84,    /** Write the buffer again */
+  SDCARD_SELECT_PRIMARY = 0xc0,   /** Talk to the first card */
+  SDCARD_SELECT_SECONDARY = 0xc1, /** Talk to the second */
+};
+
+/*
+ * The following masks are auto-generated from iomap.txt.
+ * See https://github.com/dansanderson/mega65-symbols
+ * Date: 2023-08-25
+ */
+
+/* status ($D680) */
+enum
+#ifdef __clang__
+    : uint8_t
+#endif
+{
+  SD_SDIO_BUSY_MASK = 0b00000001,     /** SDIO side busy */
+  SD_CARD_BUSY_MASK = 0b00000010,     /** The card says it is busy */
+  SD_RESET_MASK = 0b00000100,         /** Controller held in reset */
+  SD_BUFFER_MAPPED_MASK = 0b00001000, /** Sector buffer showing at 0xDE00 */
+  SD_SDHC_MASK = 0b00010000,          /** Card is SDHC, so addressed by sector */
+  SD_FSM_ERROR_MASK = 0b00100000,     /** SDIO state machine error */
+  SD_ERROR_MASK = 0b01000000,         /** SDIO error */
+  SD_SECONDARY_CARD_MASK = 0b10000000, /** Second card selected */
+};
+
+/* control ($D689) */
+enum
+#ifdef __clang__
+    : uint8_t
+#endif
+{
+  SD_BUFBIT8_MASK = 0b00000001,  /** (read only) bit 8 of the buffer pointer */
+  SD_BUFFFULL_MASK = 0b00000010, /** (read only) a sector arrived, unread */
+  SD_HNDSHK_MASK = 0b00000100,   /** The card's handshake signal */
+  SD_DRDY_MASK = 0b00001000,     /** The card's data-ready signal */
+  SD_FDCSWAP_MASK = 0b00100000,  /** Swap floppy drives 0 and 1 */
+  /// Which sector buffer 0xFFD6E00 shows: set for the SD card's, clear for the
+  /// F011's. Set it before writing a sector, or the write ships whatever the
+  /// F011's buffer last held.
+  SD_BUFFSEL_MASK = 0b10000000,
+};
+
+/* image_type ($D68A): bits 0-3 read machine state, bits 6-7 write the type */
+enum
+#ifdef __clang__
+    : uint8_t
+#endif
+{
+  SD_CDC00_MASK = 0b00000001,    /** (read only) colour RAM is at 0xDC00 */
+  SD_VICIII_MASK = 0b00000010,   /** (read only) VIC-IV or ethernet bank shown */
+  SD_VFDC0_MASK = 0b00000100,    /** (read only) drive 0 served over the monitor */
+  SD_VFDC1_MASK = 0b00001000,    /** (read only) drive 1 served over the monitor */
+  SDFDC_D0D64_MASK = 0b01000000, /** Drive 0 image is a D64, else a D81 */
+  SDFDC_D1D64_MASK = 0b10000000, /** Drive 1 image is a D64, else a D81 */
+};
+
+/* flags ($D68B) */
+enum
+#ifdef __clang__
+    : uint8_t
+#endif
+{
+  SDFDC_D0IMG_MASK = 0b00000001, /** Drive 0 uses an image, else the real drive */
+  SDFDC_D0P_MASK = 0b00000010,   /** Drive 0 has media */
+  /// Drive 0 write *enable*, whatever the name iomap.txt gives it: the
+  /// hardware stores and returns the complement, so setting this permits
+  /// writes and clearing it protects the drive.
+  SDFDC_D0WP_MASK = 0b00000100,
+  SDFDC_D1IMG_MASK = 0b00001000, /** Drive 1 uses an image, else the real drive */
+  SDFDC_D1P_MASK = 0b00010000,   /** Drive 1 has media */
+  SDFDC_D1WP_MASK = 0b00100000,  /** Drive 1 write enable; see SDFDC_D0WP_MASK */
+  SDFDC_D0MD_MASK = 0b01000000,  /** Drive 0 image is a D65, else a D81 */
+  SDFDC_D1MD_MASK = 0b10000000,  /** Drive 1 image is a D65, else a D81 */
+};
+
+#ifdef __cplusplus
+} // extern block
+#endif
+
+#endif // _SDCARD_H

--- a/mos-platform/mega65/_vic3.h
+++ b/mos-platform/mega65/_vic3.h
@@ -6,6 +6,8 @@
 #ifndef _VIC3_H
 #define _VIC3_H
 
+#include <stdint.h>
+
 /*
  * The following defines are auto-generated from iomap.txt.
  * See https://github.com/dansanderson/mega65-symbols

--- a/mos-platform/mega65/_vic4.h
+++ b/mos-platform/mega65/_vic4.h
@@ -315,6 +315,22 @@ struct __vic4 {
 static_assert(sizeof(__vic4) == 0x80);
 #endif
 
+/// Values written to VICIV.key to choose which registers appear at
+/// 0xD000-0xDFFF. Write the two bytes of a pair in that order; any other
+/// value returns to VIC-II.
+enum
+#ifdef __clang__
+    : uint8_t
+#endif
+{
+  VIC4_KEY_VICIII_A = 0xa5, //!< ...then VIC4_KEY_VICIII_B for C65/VIC-III
+  VIC4_KEY_VICIII_B = 0x96,
+  VIC4_KEY_VICIV_A = 0x47, //!< ...then VIC4_KEY_VICIV_B for MEGA65/VIC-IV
+  VIC4_KEY_VICIV_B = 0x53,
+  VIC4_KEY_ETH_A = 0x45, //!< ...then VIC4_KEY_ETH_B for the 45E100 buffers
+  VIC4_KEY_ETH_B = 0x54,
+};
+
 /*
  * The following masks are auto-generated from iomap.txt.
  * See https://github.com/dansanderson/mega65-symbols

--- a/mos-platform/mega65/cbm_k_cint.c
+++ b/mos-platform/mega65/cbm_k_cint.c
@@ -1,0 +1,16 @@
+// Copyright 2026 LLVM-MOS Project
+// Licensed under the Apache License, Version 2.0 with LLVM Exceptions.
+// See https://github.com/llvm-mos/llvm-mos-sdk/blob/main/LICENSE for license
+// information.
+
+// MEGA65 override of commodore cbm_k_cint. CINT copies the mouse window with
+// ldq/stq, which loads Z; compiled code needs Z back at 0.
+// Initialize the screen editor and VIC-IV (CINT, $FF81).
+// Resets screen geometry, cursor position, and character set.
+void cbm_k_cint(void) {
+  asm volatile("jsr __CINT\n"
+               "ldz #0"
+               :
+               :
+               : "a", "x", "y", "p");
+}

--- a/mos-platform/mega65/cbm_k_load.c
+++ b/mos-platform/mega65/cbm_k_load.c
@@ -1,0 +1,23 @@
+// Copyright 2026 LLVM-MOS Project
+// Licensed under the Apache License, Version 2.0 with LLVM Exceptions.
+// See https://github.com/llvm-mos/llvm-mos-sdk/blob/main/LICENSE for license
+// information.
+
+// MEGA65 override of commodore cbm_k_load. Delegates to mega65_k_load(),
+// which restores Z after the KERNAL call.
+
+#include <mega65.h>
+
+// Load or verify a file (LOAD, $FFD5).
+// Requires cbm_k_setlfs() and cbm_k_setnam() called first.
+// On MEGA65, also call mega65_k_setbnk() to set the data/filename banks.
+// @param flag       0=load, 1=verify.
+// @param load_addr  Destination address (used when SA=0).
+// @return Pointer past the last byte loaded, or error code as pointer.
+void *cbm_k_load(const uint8_t flag, void *load_addr) {
+  void *end_addr;
+  uint8_t err = mega65_k_load(flag, load_addr, &end_addr);
+  // end_addr is only written on success, so the error has to be what comes
+  // back otherwise -- as a pointer, matching the commodore version.
+  return err ? (void *)(uint16_t)err : end_addr;
+}

--- a/mos-platform/mega65/cbm_k_save.c
+++ b/mos-platform/mega65/cbm_k_save.c
@@ -1,0 +1,43 @@
+// Copyright 2026 LLVM-MOS Project
+// Licensed under the Apache License, Version 2.0 with LLVM Exceptions.
+// See https://github.com/llvm-mos/llvm-mos-sdk/blob/main/LICENSE for license
+// information.
+
+#include <stdint.h>
+
+// MEGA65 override of commodore cbm_k_save. SAVE leaves Z at 0 only as an
+// artefact of its own [sal],z addressing; this wrapper clears it explicitly.
+// Save memory to a file (SAVE, $FFD8).
+// Requires cbm_k_setlfs() and cbm_k_setnam() called first.
+// On MEGA65, also call mega65_k_setbnk() to set the data/filename banks.
+// @param startaddr        Start of memory region to save.
+// @param endaddr_plusone  First byte past the end (not saved).
+// @return 0 on success, or KERNAL error code (1-9).
+// Repeated from cbm.h, which callers compile against, because including it
+// here needs __CBM__ and the platform build does not define it.
+uint8_t cbm_k_save(void *startaddr, void *endaddr_plusone)
+    __attribute__((leaf));
+
+uint8_t cbm_k_save(void *startaddr, void *endaddr_plusone) {
+  uint8_t end_lo = (uint8_t)(uint16_t)endaddr_plusone;
+  uint8_t end_hi = (uint8_t)((uint16_t)endaddr_plusone >> 8);
+  uint8_t err;
+  // SAVE reads the start address through a zero-page pointer, so it must live
+  // in one: an imaginary register pair is the cheapest such home, and
+  // "lda #%[zp]" assembles to its zero-page address.
+  uint16_t zp_ptr = (uint16_t)startaddr;
+
+  // The save runs through X and Y, and the carry is consumed here because
+  // "=c" outputs miscompile (see mega65_k_load.c).
+  asm volatile("lda #%[zp]\n"
+               "jsr __SAVE\n"
+               "ldz #0\n"
+               "bcs 1f\n"
+               "lda #0\n"
+               "1:\n"
+               : "=&a"(err), [zp] "+r"(zp_ptr), "+x"(end_lo), "+y"(end_hi)
+               :
+               : "p");
+
+  return err;
+}

--- a/mos-platform/mega65/d81.py
+++ b/mos-platform/mega65/d81.py
@@ -1,0 +1,379 @@
+#!/usr/bin/env python3
+# Copyright 2026 LLVM-MOS Project
+# Licensed under the Apache License, Version 2.0 with LLVM Exceptions.
+# See https://github.com/llvm-mos/llvm-mos-sdk/blob/main/LICENSE for license
+# information.
+"""Create a Commodore 1581 (.d81) disk image. Pure stdlib.
+
+Geometry: 80 tracks x 40 sectors x 256 bytes. Track 40 holds the header (40/0),
+the BAM (40/1 tracks 1-40, 40/2 tracks 41-80) and the directory (40/3..40/39),
+and is allocated whole at format time, leaving 3160 blocks free.
+
+Follows Peter Schepers / VICE "D81 (Disk Image) Format"
+"""
+
+import argparse
+import itertools
+import os
+import sys
+from collections.abc import Iterator
+from pathlib import Path
+
+TRACKS = 80
+SECTORS_PER_TRACK = 40
+SECTOR_SIZE = 256
+IMAGE_SIZE = TRACKS * SECTORS_PER_TRACK * SECTOR_SIZE
+
+# Track 40 is the directory track: reserved whole, so it never holds data.
+DIR_TRACK = 40
+HEADER_SECTOR = 0
+BAM_SECTOR_LO = 1
+BAM_SECTOR_HI = 2
+FIRST_DIR_SECTOR = 3
+LAST_DIR_SECTOR = 39
+
+# Two of every sector go to the next-block link, leaving 254 for data.
+DATA_PER_SECTOR = 254
+ENTRIES_PER_SECTOR = 8
+ENTRY_SIZE = 32
+DIR_ENTRIES = (LAST_DIR_SECTOR - FIRST_DIR_SECTOR + 1) * ENTRIES_PER_SECTOR
+NAME_LEN = 16
+DISK_ID_LEN = 2
+PAD = 0xA0  # CBM pads names with $A0, not spaces
+
+# One BAM entry per track: a free-block count, then a bitmap with one bit per
+# sector. The entries start at BAM_ENTRIES and run to the end of the sector.
+BAM_ENTRIES = 0x10
+BAM_BITMAP_BYTES = (SECTORS_PER_TRACK + 7) // 8
+BAM_ENTRY_SIZE = 1 + BAM_BITMAP_BYTES
+
+FILE_TYPES = {"DEL": 0, "SEQ": 1, "PRG": 2, "USR": 3, "REL": 4}
+EXT_TO_TYPE = {".prg": "PRG", ".seq": "SEQ", ".usr": "USR", ".del": "DEL"}
+
+
+def _to_petscii(s: str) -> bytes:
+    """ASCII to PETSCII for disk and file names.
+
+    Both cases map to $41-$5A, which is what the KERNAL's directory match
+    compares against. Deliberately not the reversible c1541 mapping, which
+    sends 'A'-'Z' to $C1-$DA instead and so depends on the caller's case.
+    """
+    def one(c: int) -> int:
+        if 0x61 <= c <= 0x7A:  # fold lower case up
+            return c - 0x20
+        return c if 0x20 <= c <= 0x5F else 0x3F  # '?'
+
+    return bytes(one(ord(ch)) for ch in s)
+
+
+def _petscii_field(s: str, length: int) -> bytes:
+    """PETSCII, truncated to length and padded with $A0 as CBM expects."""
+    return _to_petscii(s)[:length].ljust(length, bytes([PAD]))
+
+
+class D81:
+    def __init__(self, name: str = "EMPTY", disk_id: str = "00") -> None:
+        self.data = bytearray(IMAGE_SIZE)
+        self._format(name, disk_id)
+
+    def _sector(self, track: int, sec: int) -> memoryview:
+        """A writable view of one sector. Tracks count from 1, sectors from 0."""
+        if not (1 <= track <= TRACKS) or not (0 <= sec < SECTORS_PER_TRACK):
+            raise ValueError(f"bad t/s {track}/{sec}")
+        off = ((track - 1) * SECTORS_PER_TRACK + sec) * SECTOR_SIZE
+        return memoryview(self.data)[off : off + SECTOR_SIZE]
+
+    @staticmethod
+    def _bam_loc(track: int) -> tuple[int, int]:
+        """BAM sector on track 40, and the offset of this track's 6-byte entry."""
+        half = TRACKS // 2
+        if 1 <= track <= half:
+            return BAM_SECTOR_LO, BAM_ENTRIES + (track - 1) * BAM_ENTRY_SIZE
+        if half < track <= TRACKS:
+            return BAM_SECTOR_HI, BAM_ENTRIES + (track - half - 1) * BAM_ENTRY_SIZE
+        raise ValueError(f"bad track {track}")
+
+    def _is_free(self, track: int, sec: int) -> bool:
+        """True if the BAM bit is set: in CBM BAMs a set bit means free."""
+        bs, off = self._bam_loc(track)
+        bam = self._sector(DIR_TRACK, bs)
+        return bool(bam[off + 1 + (sec >> 3)] & (1 << (sec & 7)))
+
+    def _allocate(self, track: int, sec: int) -> None:
+        """Clear the sector's BAM bit and decrement its track free count."""
+        bs, off = self._bam_loc(track)
+        bam = self._sector(DIR_TRACK, bs)
+        i, mask = off + 1 + (sec >> 3), 1 << (sec & 7)
+        if not bam[i] & mask:
+            raise RuntimeError(f"sector {track}/{sec} already allocated")
+        bam[i] &= ~mask & 0xFF
+        bam[off] -= 1
+
+    def blocks_free(self) -> int:
+        return sum(
+            self._sector(DIR_TRACK, bs)[off]
+            for bs, off in map(self._bam_loc, range(1, TRACKS + 1))
+        )
+
+    def _format(self, name: str, disk_id: str = "00") -> None:
+        """Write the header, BAM and first directory sector.
+
+        The whole directory track is marked allocated, so file data never
+        lands on it. Relies on the buffer being zeroed, which is why this runs
+        only from __init__: a file type of 0 is what marks a directory entry
+        unused.
+        """
+        did = _petscii_field(disk_id, DISK_ID_LEN)
+
+        h = self._sector(DIR_TRACK, HEADER_SECTOR)
+        h[0x00], h[0x01] = DIR_TRACK, FIRST_DIR_SECTOR
+        h[0x02] = 0x44  # 'D', disk format type
+        h[0x03] = 0x00
+        h[0x04:0x14] = _petscii_field(name, NAME_LEN)
+        h[0x14:0x16] = bytes([PAD, PAD])
+        h[0x16:0x18] = did
+        h[0x18] = PAD
+        h[0x19] = 0x33  # DOS version '3'
+        h[0x1A] = 0x44  # disk version 'D'
+        h[0x1B:0x1D] = bytes([PAD, PAD])
+
+        lo = self._sector(DIR_TRACK, BAM_SECTOR_LO)
+        lo[0x00], lo[0x01] = DIR_TRACK, BAM_SECTOR_HI
+        hi = self._sector(DIR_TRACK, BAM_SECTOR_HI)
+        hi[0x00], hi[0x01] = 0x00, 0xFF
+        for b in (lo, hi):
+            b[0x02] = 0x44  # version 'D'
+            b[0x03] = 0xBB  # its one's complement
+            b[0x04:0x06] = did
+            b[0x06] = 0xC0  # I/O byte: verify on, check CRC
+            b[0x07] = 0x00  # autoloader flag
+
+        for t in range(1, TRACKS + 1):
+            bs, off = self._bam_loc(t)
+            b = self._sector(DIR_TRACK, bs)
+            b[off] = SECTORS_PER_TRACK
+            b[off + 1 : off + BAM_ENTRY_SIZE] = b"\xff" * BAM_BITMAP_BYTES
+
+        bs, off = self._bam_loc(DIR_TRACK)  # track 40 is reserved whole
+        b = self._sector(DIR_TRACK, bs)
+        b[off] = 0
+        b[off + 1 : off + BAM_ENTRY_SIZE] = b"\x00" * BAM_BITMAP_BYTES
+
+        d = self._sector(DIR_TRACK, FIRST_DIR_SECTOR)
+        d[0x00], d[0x01] = 0x00, 0xFF
+
+    def _free_blocks(self) -> Iterator[tuple[int, int]]:
+        """Every free block in track order, skipping the directory track."""
+        return (
+            (t, s)
+            for t in range(1, TRACKS + 1)
+            if t != DIR_TRACK
+            for s in range(SECTORS_PER_TRACK)
+            if self._is_free(t, s)
+        )
+
+    def _alloc_chain(self, count: int) -> list[tuple[int, int]]:
+        """Reserve count blocks, first-fit, and return them in chain order."""
+        # No interleave: an image file has no rotational latency to hide.
+        blocks = list(itertools.islice(self._free_blocks(), count))
+        if len(blocks) < count:
+            raise RuntimeError(
+                f"disk full: need {count} blocks, {self.blocks_free()} free"
+            )
+        for t, s in blocks:
+            self._allocate(t, s)
+        return blocks
+
+    def _alloc_dir_entry(self) -> tuple[int, int]:
+        """Directory sector number, and the offset of a free 32-byte entry."""
+        cur = FIRST_DIR_SECTOR
+        while True:
+            d = self._sector(DIR_TRACK, cur)
+            for i in range(ENTRIES_PER_SECTOR):
+                off = i * ENTRY_SIZE
+                if d[off + 2] == 0x00:  # unused file-type byte
+                    return cur, off
+            if d[0] == DIR_TRACK:  # a further sector already exists
+                cur = d[1]
+                continue
+            nxt = cur + 1
+            if nxt > LAST_DIR_SECTOR:
+                raise RuntimeError(f"directory full ({DIR_ENTRIES} entries)")
+            d[0], d[1] = DIR_TRACK, nxt
+            nd = self._sector(DIR_TRACK, nxt)
+            nd[0], nd[1] = 0x00, 0xFF
+            cur = nxt
+
+    def add_file(self, cbm_name: str, data: bytes, ftype: str = "PRG") -> int:
+        """Write data as a linked sector chain and add its directory entry.
+
+        Returns the block count. Each sector holds 254 bytes behind a 2-byte
+        link to the next; in the last, that link is 0 and the byte offset of
+        the final valid byte, not a length.
+        """
+        if not data:
+            raise ValueError(f"{cbm_name}: refusing to write an empty file")
+        code = FILE_TYPES[ftype.upper()]
+        chunks = [
+            bytes(data[i : i + DATA_PER_SECTOR])
+            for i in range(0, len(data), DATA_PER_SECTOR)
+        ]
+        blocks = self._alloc_chain(len(chunks))
+
+        for i, (t, s) in enumerate(blocks):
+            sec = self._sector(t, s)
+            if i + 1 < len(blocks):
+                sec[0], sec[1] = blocks[i + 1]
+            else:
+                # End of chain: byte 1 is the offset of the last valid byte.
+                sec[0], sec[1] = 0x00, len(chunks[i]) + 1
+            sec[2 : 2 + len(chunks[i])] = chunks[i]
+
+        ds, off = self._alloc_dir_entry()
+        e = self._sector(DIR_TRACK, ds)
+        e[off + 2] = 0x80 | code  # bit 7 = closed
+        e[off + 3], e[off + 4] = blocks[0]
+        e[off + 5 : off + 5 + NAME_LEN] = _petscii_field(cbm_name, NAME_LEN)
+        e[off + 30] = len(blocks) & 0xFF
+        e[off + 31] = (len(blocks) >> 8) & 0xFF
+        return len(blocks)
+
+    def save(self, path: str) -> None:
+        """Write the image out."""
+        Path(path).write_bytes(self.data)
+
+
+def _parse_spec(spec: str) -> tuple[str, str, str]:
+    """PATH, or PATH=CBMNAME, or PATH=CBMNAME,TYPE."""
+    path, _, rest = spec.partition("=")
+    name, _, ftype = rest.partition(",")
+    if not name:
+        name = os.path.splitext(os.path.basename(path))[0]
+    if not ftype:
+        ftype = EXT_TO_TYPE.get(os.path.splitext(path)[1].lower(), "PRG")
+    return path, name, ftype.upper()
+
+
+def _read_file(d: "D81", cbm_name: str) -> bytes:
+    """Walk a file's sector chain back into bytes, for the self-test."""
+    want = _petscii_field(cbm_name, NAME_LEN)
+    cur = FIRST_DIR_SECTOR
+    while True:
+        sec = d._sector(DIR_TRACK, cur)
+        for i in range(ENTRIES_PER_SECTOR):
+            off = i * ENTRY_SIZE
+            if sec[off + 2] and bytes(sec[off + 5 : off + 5 + NAME_LEN]) == want:
+                t, s = sec[off + 3], sec[off + 4]
+                out = bytearray()
+                while t:
+                    blk = d._sector(t, s)
+                    t, s = blk[0], blk[1]
+                    # In the last block the link is 0 and s is the offset of
+                    # the final valid byte.
+                    out += blk[2 : s + 1] if t == 0 else blk[2:]
+                return bytes(out)
+        if sec[0] != DIR_TRACK:
+            raise KeyError(cbm_name)
+        cur = sec[1]
+
+
+def _selftest() -> None:
+    """Check geometry, BAM accounting, name encoding and chain round-trip."""
+    empty = (TRACKS - 1) * SECTORS_PER_TRACK
+
+    d = D81("TESTDISK", "42")
+    assert len(d.data) == IMAGE_SIZE
+    assert d.blocks_free() == empty, d.blocks_free()
+    # the directory track is reserved whole, so no file can land on it
+    assert not any(d._is_free(DIR_TRACK, s) for s in range(SECTORS_PER_TRACK))
+    assert all(d._is_free(1, s) for s in range(SECTORS_PER_TRACK))
+
+    for bad in ((0, 0), (TRACKS + 1, 0), (1, SECTORS_PER_TRACK), (1, -1)):
+        try:
+            d._sector(*bad)
+        except ValueError:
+            pass
+        else:
+            raise AssertionError(f"sector{bad} should be rejected")
+
+    d._allocate(1, 0)
+    assert not d._is_free(1, 0)
+    assert d.blocks_free() == empty - 1
+    try:
+        d._allocate(1, 0)
+    except RuntimeError:
+        pass
+    else:
+        raise AssertionError("double allocation should be rejected")
+
+    # A payload that does not divide evenly, so the last block exercises the
+    # byte-offset convention rather than a full sector.
+    d = D81()
+    payload = bytes(range(256)) * 3
+    want_blocks = -(-len(payload) // DATA_PER_SECTOR)
+    assert d.add_file("ROUNDTRIP", payload) == want_blocks
+    assert d.blocks_free() == empty - want_blocks
+    assert _read_file(d, "ROUNDTRIP") == payload
+
+    # Exactly one full sector: the last block is full and must not be truncated.
+    d = D81()
+    exact = bytes(range(254))
+    assert d.add_file("EXACT", exact) == 1
+    assert _read_file(d, "EXACT") == exact
+
+    try:
+        d.add_file("EMPTY", b"")
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("an empty file should be rejected")
+
+    # Names are upper-cased and $A0-padded, and truncated to the field.
+    assert _petscii_field("ab", 4) == b"AB\xa0\xa0"
+    assert _petscii_field("x" * 20, NAME_LEN) == b"X" * NAME_LEN
+    assert _to_petscii("Az9") == b"AZ9"
+    assert _to_petscii("\u00e9") == b"?"
+
+    assert _parse_spec("dir/f.prg") == ("dir/f.prg", "f", "PRG")
+    assert _parse_spec("f.bin=NAME") == ("f.bin", "NAME", "PRG")
+    assert _parse_spec("f.bin=NAME,SEQ") == ("f.bin", "NAME", "SEQ")
+    assert _parse_spec("f.seq") == ("f.seq", "f", "SEQ")
+
+    print("d81.py: self-test passed", file=sys.stderr)
+
+
+def main(argv=None) -> None:
+    ap = argparse.ArgumentParser(description="Create a .d81 disk image.")
+    ap.add_argument("image", nargs="?")
+    ap.add_argument(
+        "files", nargs="*", help="PATH[=CBMNAME[,TYPE]] with TYPE in PRG SEQ USR DEL"
+    )
+    ap.add_argument("-n", "--name", default="EMPTY", help="disk name, 16 chars")
+    ap.add_argument("-i", "--id", default="00", dest="disk_id", help="disk ID, 2 chars")
+    ap.add_argument(
+        "--selftest", action="store_true", help="check the format code and exit"
+    )
+    # Intermixed so options may follow the file list, which a caller building
+    # the command line by appending naturally produces.
+    a = ap.parse_intermixed_args(argv)
+
+    if a.selftest:
+        _selftest()
+        return
+    if a.image is None:
+        ap.error("an image path is required")
+
+    d = D81(a.name, a.disk_id)
+    for spec in a.files:
+        path, cbm, ftype = _parse_spec(spec)
+        if ftype not in FILE_TYPES:
+            ap.error(f"unknown file type {ftype!r}")
+        with open(path, "rb") as f:
+            blocks = d.add_file(cbm, f.read(), ftype)
+        print(f"{cbm:<16} {ftype:<3} {blocks:4d} blocks", file=sys.stderr)
+    d.save(a.image)
+    print(f"{d.blocks_free()} blocks free", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/mos-platform/mega65/kernal.S
+++ b/mos-platform/mega65/kernal.S
@@ -70,4 +70,23 @@ weakdef GETIN
 weakdef CLALL
 weakdef UDTIM
 weakdef SCREEN
+weakdef PLOT
 weakdef IOBASE
+
+; MEGA65 extended jump table
+weakdef SYSFLAGS
+weakdef ADDKEY
+weakdef CLOSE_ALL
+weakdef GETIO
+weakdef GETLFS
+weakdef LKUPLA
+weakdef LKUPSA
+weakdef PFKEY
+weakdef SAVEFL
+weakdef SWAPPER
+weakdef SETBNK
+weakdef JSRFAR
+weakdef JMPFAR
+weakdef LDA_FAR
+weakdef STA_FAR
+weakdef CMP_FAR

--- a/mos-platform/mega65/link.ld
+++ b/mos-platform/mega65/link.ld
@@ -27,8 +27,37 @@ INCLUDE commodore.ld
 
 INPUT(unmap-basic.o)
 
-/* Set initial soft stack address to end of BASIC area. (It grows down.) */
-__stack = 0xd000;
+/* Soft stack, growing down from the end of the BASIC area.
+ *
+ * $C000-$CFFF is RAM only while ROMC ($D030 bit 5) stays clear, which is what
+ * unmap-basic.o arranges at startup. A program that maps the C65 ROM back --
+ * KERNAL disk I/O needs it, for the DOS interface the ROM keeps there -- makes
+ * that window read as ROM while writes still go to RAM, so anything it reads
+ * back from there returns ROM bytes. Such a program must move the stack and
+ * the top of ram below $C000:
+ *
+ *   -Wl,--defsym=__stack=0xc000
+ */
+PROVIDE(__stack = 0xd000);
+
+/* Where mega65_h_setname() stages the filename Hyppo reads.
+ *
+ * Hyppo copies a whole page and takes only its high byte, so the only choice
+ * is which page below $7F00. The stack page serves: it grows down from $01FF,
+ * and compiled code keeps its frames on the soft stack, so it never reaches a
+ * name sitting at the bottom.
+ *
+ * PROVIDE, so a program needing this page, or two names at once, can move it:
+ *
+ *   -Wl,--defsym=__mega65_h_name_buf=0x0400
+ */
+PROVIDE(__mega65_h_name_buf = 0x0100);
+
+/* Hyppo accepts page $00; we do not, because a name there would overwrite the
+ * imaginary registers. */
+ASSERT((__mega65_h_name_buf & 0xFF) == 0 && __mega65_h_name_buf >= 0x0100 &&
+       __mega65_h_name_buf < 0x7F00,
+    "__mega65_h_name_buf: hyppo copies only into a page-aligned buffer below $7F00")
 
 OUTPUT_FORMAT {
     /* Tells the LOAD command where to place the file's contents. */

--- a/mos-platform/mega65/mega65.h
+++ b/mos-platform/mega65/mega65.h
@@ -88,7 +88,7 @@ struct __hypervisor {
     };
   };
 };
-#ifdef __cplusplus
+#if defined(__mos__) && defined(__cplusplus)
 static_assert(sizeof(struct __hypervisor) == 64);
 #endif
 

--- a/mos-platform/mega65/mega65.h
+++ b/mos-platform/mega65/mega65.h
@@ -27,6 +27,7 @@ extern "C" {
 #include <_45E100.h>
 #include <_6526.h>
 #include <_dmagic.h>
+#include <_sdcard.h>
 #include <_sid.h>
 #include <_vic2.h>
 #include <_vic3.h>
@@ -179,6 +180,10 @@ enum
 #define SIDMODE (*(volatile uint8_t *)0xd63c)
 /// Hypervisor traps
 #define HYPERVISOR (*(volatile struct __hypervisor *)0xd640)
+/// MEGA65 SD card controller
+#define SDCARD (*(volatile struct __sdcard *)0xd680)
+/// F011 floppy emulation: disk images and where they are
+#define SDFDC (*(volatile struct __sdfdc *)0xd68a)
 /// Ethernet controller
 #define ETHERNET (*(volatile struct __45E100 *)0xd6e0)
 /// DMAgic DMA controller

--- a/mos-platform/mega65/mega65.h
+++ b/mos-platform/mega65/mega65.h
@@ -6,6 +6,7 @@
 #ifndef _MEGA65_H
 #define _MEGA65_H
 
+#include <stdbool.h>
 #include <stdint.h>
 
 #ifdef __cplusplus
@@ -17,6 +18,9 @@ extern "C" {
 #pragma clang diagnostic ignored "-Wgnu-anonymous-struct"
 #pragma clang diagnostic ignored "-Wnested-anon-types"
 #pragma clang diagnostic ignored "-Wgnu-binary-literal"
+// -Wfixed-enum-extension does not exist in every clang this header is used
+// with, and naming an absent group is itself a warning.
+#pragma clang diagnostic ignored "-Wunknown-warning-option"
 #pragma clang diagnostic ignored "-Wfixed-enum-extension"
 #endif
 
@@ -36,8 +40,9 @@ struct __hypervisor {
       /// Hypervisor A register storage
       uint8_t rega; // 0xD640
       /// Hypervisor X register storage
-      uint8_t regx;    // 0xD641
-      uint8_t unused1; // 0xD642
+      uint8_t regx; // 0xD641
+      /// Hypervisor Y register storage
+      uint8_t regy; // 0xD642
       /// Hypervisor Z register storage
       uint8_t regz; // 0xD643
       /// Hypervisor B register storage
@@ -137,6 +142,19 @@ struct __color_palette {
   uint8_t blue[256];  //!< Blue palette values (reversed nybl order)
 };
 
+/// 6510/45GS02 CPU port bits. Bits 0-2 drive the C64-style banking; a bit
+/// configured as an input in CPU_PORTDDR reads as 1, so clearing a ROM
+/// requires the matching direction bit to be an output.
+enum
+#ifdef __clang__
+    : uint8_t
+#endif
+{
+  CPU_PORT_LORAM = 0b00000001,  ///< BASIC ROM at $A000-$BFFF
+  CPU_PORT_HIRAM = 0b00000010,  ///< KERNAL ROM at $E000-$FFFF
+  CPU_PORT_CHAREN = 0b00000100, ///< I/O at $D000-$DFFF, else character ROM
+};
+
 /// 6510/45GS10 CPU port DDR
 #define CPU_PORTDDR (*(volatile uint8_t *)0x0000)
 /// 6510/45GS10 CPU port data
@@ -213,6 +231,587 @@ enum
   COLOR_BUBBLEGUM = 0x1E,
   COLOR_HOTTAMALES = 0x1F
 };
+
+// MEGA65 KERNAL function wrappers.
+
+/// Return type for mega65_k_scrorg()
+typedef struct {
+  uint8_t max_col;  ///< Rightmost column index (79 in 80-column mode)
+  uint8_t max_row;  ///< Bottom row index (24 for 25 rows)
+  uint8_t addr_lo;  ///< Window top-left screen address, low byte
+  uint8_t addr_hi;  ///< Window top-left screen address, high byte
+  uint8_t is_40col; ///< 0=80 column mode, 1=40 column mode
+} mega65_screen_info_t;
+
+/// Return type for mega65_k_getio()
+typedef struct {
+  uint8_t input_dev;  ///< Current input device, 0 = keyboard
+  uint8_t output_dev; ///< Current output device, 3 = screen
+} mega65_io_t;
+
+/// Return type for mega65_k_getlfs()
+typedef struct {
+  uint8_t la; ///< Logical file number
+  uint8_t fa; ///< Device number
+  uint8_t sa; ///< Secondary address, 0xFF if not set
+} mega65_lfs_t;
+
+/// Return type for mega65_k_plot_get()
+typedef struct {
+  uint8_t line; ///< Cursor line, 0-based
+  uint8_t col;  ///< Cursor column, 0-based
+} mega65_plot_t;
+
+/// Return type for mega65_k_rdtim()
+typedef struct {
+  uint8_t hours;   ///< Hours 0-23 in BCD (e.g. 0x14 = 14)
+  uint8_t minutes; ///< Minutes 0-59 in BCD (e.g. 0x30 = 30)
+  uint8_t seconds; ///< Seconds 0-59 in BCD (e.g. 0x57 = 57)
+  uint8_t tenths;  ///< Tenths of a second 0-9
+} mega65_tod_t;
+
+/// Add a PETSCII character to the keyboard input buffer.
+/// The buffer is consumed by GETIN calls, not by the KERNAL IRQ.
+///
+/// @param petscii_char  PETSCII character code
+/// @return 0 on success, 1 if the buffer is full
+uint8_t mega65_k_addkey(unsigned char petscii_char) __attribute__((leaf));
+
+/// Close all open files on the specified device.
+/// Restores default I/O channels if the current channel was on that device.
+///
+/// @param device  Device number (0-31)
+void mega65_k_close_all(uint8_t device) __attribute__((leaf));
+
+/// Read the current input and output devices.
+/// Modified by CHKIN and CKOUT.
+///
+/// @return input device (0=keyboard) and output device (3=screen)
+mega65_io_t mega65_k_getio(void) __attribute__((leaf));
+
+/// Read the current file parameters (logical address, device, secondary
+/// address). Useful to determine the boot device before performing other disk
+/// I/O.
+///
+/// @return logical file number, device number, and secondary address
+///         (sa is 0xFF if not set)
+mega65_lfs_t mega65_k_getlfs(void) __attribute__((leaf));
+
+/// Search for a logical file number in use.
+///
+/// @param la  Logical file number to search for
+/// @param fa  Pointer to receive device number (if found)
+/// @param sa  Pointer to receive secondary address (if found)
+/// @return 0 if found, 1 if not found
+uint8_t mega65_k_lkupla(uint8_t la, uint8_t *fa, uint8_t *sa)
+    __attribute__((leaf));
+
+/// Search for a secondary address in use.
+///
+/// @param sa  Secondary address to search for
+/// @param la  Pointer to receive logical file number (if found)
+/// @param fa  Pointer to receive device number (if found)
+/// @return 0 if found, 1 if not found
+uint8_t mega65_k_lkupsa(uint8_t sa, uint8_t *la, uint8_t *fa)
+    __attribute__((leaf));
+
+/// Load or verify a file. Supports MEGA65 raw mode (flag bit 6).
+/// flag: 0x00=load to address, 0x01=verify, 0x40=raw load, 0x41=raw verify.
+/// Raw mode treats the first two bytes as data instead of a PRG header.
+/// Requires SETBNK, SETLFS, SETNAM called first.
+///
+/// @param flag       Load flags (0=load, 1=verify, 0x40=raw load, 0x41=raw
+/// verify)
+/// @param load_addr  Destination address (used if SA=0; ignored if SA!=0)
+/// @param end_addr   Pointer to receive end address+1 on success
+/// @return 0 on success, or KERNAL error code (1-9)
+uint8_t mega65_k_load(uint8_t flag, void *load_addr, void **end_addr)
+    __attribute__((leaf));
+
+/// Get cursor position relative to the active window.
+///
+/// @return cursor line and column, both 0-based
+mega65_plot_t mega65_k_plot_get(void) __attribute__((leaf));
+
+/// Set cursor position relative to the active window.
+///
+/// @param line  Cursor line (0-based)
+/// @param col   Cursor column (0-based)
+void mega65_k_plot_set(uint8_t line, uint8_t col) __attribute__((leaf));
+
+/// Read the CIA1 time-of-day clock.
+/// Returns hours, minutes, seconds (BCD), and tenths of a second.
+/// This reads the CIA1 TOD, not the battery-backed RTC.
+mega65_tod_t mega65_k_rdtim(void) __attribute__((leaf));
+
+/// Get screen window size and properties (SCRORG).
+/// The KERNAL reports the window as maximum indices, not counts, so a
+/// full 80x25 screen comes back as max_col=79, max_row=24.
+mega65_screen_info_t mega65_k_scrorg(void) __attribute__((leaf));
+
+/// Set memory bank and filename bank for I/O operations (LOAD, SAVE, OPEN).
+/// For simple bank mode (banks 0-5 in the first megabyte).
+/// Must be called before LOAD, SAVE, or OPEN.
+///
+/// @param mem_bank Memory bank (0-5)
+/// @param fn_bank  Filename bank (0-5)
+void mega65_k_setbnk(uint8_t mem_bank, uint8_t fn_bank) __attribute__((leaf));
+
+/// Set 28-bit memory and filename addresses for I/O operations.
+/// For accessing addresses beyond the first megabyte.
+/// The lower 16 bits of each address are set via other calls (SETNAM, LOAD).
+///
+/// @param mem_mb  Memory megabyte (bits 24-27, 0x0-0xF)
+/// @param mem_hi  Memory address bits 16-23
+/// @param fn_mb   Filename megabyte (bits 24-27, 0x0-0xF)
+/// @param fn_hi   Filename address bits 16-23
+void mega65_k_setbnk_28(uint8_t mem_mb, uint8_t mem_hi, uint8_t fn_mb,
+                        uint8_t fn_hi) __attribute__((leaf));
+
+/// Save memory to a file with optional raw mode (MEGA65 SAVEFL, $FF3B).
+/// In raw mode, the two-byte PRG address header is omitted.
+/// The memory region must fit within a single bank.
+/// Requires SETBNK, SETLFS, SETNAM called first.
+///
+/// @param start_addr       Start of memory region to save
+/// @param end_addr_plus1   End address + 1 (first byte NOT saved)
+/// @param raw              true for raw mode (omit PRG header)
+/// @return 0 on success, or KERNAL error code (1-9)
+uint8_t mega65_k_savefl(const void *start_addr, const void *end_addr_plus1,
+                        bool raw) __attribute__((leaf));
+
+/// Enable or disable KERNAL messages (LOADING, SAVING, I/O ERROR).
+/// These are disabled by default.
+///
+/// @param mode  Bit 7 = control messages, bit 6 = error messages
+void mega65_k_setmsg(uint8_t mode) __attribute__((leaf));
+
+/// Set the CIA1 time-of-day clock.
+/// All values are in BCD format (e.g. 0x59 = 59 decimal).
+/// This sets the CIA1 TOD, not the battery-backed RTC.
+///
+/// @param hours    Hours 0-23 in BCD
+/// @param minutes  Minutes 0-59 in BCD
+/// @param seconds  Seconds 0-59 in BCD
+/// @param tenths   Tenths of a second 0-9
+void mega65_k_settim(uint8_t hours, uint8_t minutes, uint8_t seconds,
+                     uint8_t tenths) __attribute__((leaf));
+
+/// Keyboard lock bits, read and written by mega65_k_sysflags_get/_set.
+/// Bits 0-3 are reserved and must be zero.
+enum
+#ifdef __clang__
+    : uint8_t
+#endif
+{
+  MEGA65_LOCK_GO64 = 0b00010000,       ///< GO64 command locked out
+  MEGA65_LOCK_RAW_FKEYS = 0b00100000,  ///< Function keys give raw keys
+  MEGA65_LOCK_NO_SCROLL = 0b01000000,  ///< No-Scroll key locked out
+  MEGA65_LOCK_MEGA_SHIFT = 0b10000000, ///< MEGA+Shift charset toggle locked out
+};
+
+/// Read the keyboard lock bits (SYSFLAGS).
+///
+/// @return the MEGA65_LOCK_* bits currently set
+uint8_t mega65_k_sysflags_get(void) __attribute__((leaf));
+
+/// Set the keyboard lock bits (SYSFLAGS).
+///
+/// @param locks  MEGA65_LOCK_* bits to apply
+void mega65_k_sysflags_set(uint8_t locks) __attribute__((leaf));
+
+/// Toggle between 40x25 and 80x25 text modes.
+void mega65_k_swapper(void) __attribute__((leaf));
+
+/// Read a byte from an address in any MEGA65 bank via KERNAL LDA_FAR ($FF74).
+/// Uses 32-bit flat addressing internally; does not change the memory map.
+/// Equivalent to lda (addr),y in the given bank.
+///
+/// @param bank      MEGA65 64K bank number (0-5)
+/// @param addr      Base address within the bank
+/// @param y_offset  Index added to addr
+/// @return Byte value at bank:addr+y_offset
+uint8_t mega65_k_lda_far(uint8_t bank, uint16_t addr, uint8_t y_offset)
+    __attribute__((leaf));
+
+/// Store a byte to an address in any MEGA65 bank via KERNAL STA_FAR ($FF77).
+/// Uses 32-bit flat addressing internally; does not change the memory map.
+/// Equivalent to sta (addr),y in the given bank.
+///
+/// @param bank      MEGA65 64K bank number (0-5)
+/// @param addr      Base address within the bank
+/// @param y_offset  Index added to addr
+/// @param value     Byte to store
+void mega65_k_sta_far(uint8_t bank, uint16_t addr, uint8_t y_offset,
+                      uint8_t value) __attribute__((leaf));
+
+/// Compare a byte with an address in any MEGA65 bank via KERNAL CMP_FAR
+/// ($FF7A). Uses 32-bit flat addressing internally; does not change the memory
+/// map. Equivalent to cmp (addr),y in the given bank.
+///
+/// @param bank      MEGA65 64K bank number (0-5)
+/// @param addr      Base address within the bank
+/// @param y_offset  Index added to addr
+/// @param value     Byte to compare against
+/// @return 0 if equal, 1 if not equal
+uint8_t mega65_k_cmp_far(uint8_t bank, uint16_t addr, uint8_t y_offset,
+                         uint8_t value) __attribute__((leaf));
+
+// Hyppo hypervisor service wrappers. These operate on the SD card FAT
+// filesystem directly, bypassing the KERNAL and D81 disk images, and are safe
+// to use with banking.
+//
+// Trap convention: LDA #value : STA $D640 : CLV. The CLV is a mandatory
+// filler -- the byte after the STA may be consumed by the trap return, so it
+// must not be an instruction that matters.
+// Success: C=1. Error: C=0, error code in A.
+
+/// Hyppo hypervisor error codes.
+/// Functions return MEGA65_H_OK (0) on success, or an error code on failure.
+typedef enum
+#ifdef __clang__
+    : uint8_t
+#endif
+{ MEGA65_H_OK = 0x00,                     ///< Success
+  MEGA65_H_ERR_PARTITION = 0x01,          ///< Partition type not supported
+  MEGA65_H_ERR_BAD_SIGNATURE = 0x02,      ///< Missing/incorrect signature
+  MEGA65_H_ERR_SMALL_FAT = 0x03,          ///< FAT12/FAT16 not supported
+  MEGA65_H_ERR_TOO_MANY_RESERVED = 0x04,  ///< >65535 reserved sectors
+  MEGA65_H_ERR_NOT_TWO_FATS = 0x05,       ///< Partition lacks two FAT copies
+  MEGA65_H_ERR_TOO_FEW_CLUSTERS = 0x06,   ///< Too few clusters
+  MEGA65_H_ERR_READ_TIMEOUT = 0x07,       ///< SD card read timeout
+  MEGA65_H_ERR_PARTITION_ERROR = 0x08,    ///< Unspecified partition error
+  MEGA65_H_ERR_INVALID_ADDRESS = 0x10,    ///< Invalid address argument
+  MEGA65_H_ERR_ILLEGAL_VALUE = 0x11,      ///< Illegal value argument
+  MEGA65_H_ERR_READ_ERROR = 0x20,         ///< Unspecified read error
+  MEGA65_H_ERR_WRITE_ERROR = 0x21,        ///< Unspecified write error
+  MEGA65_H_ERR_NO_SUCH_DRIVE = 0x80,      ///< Drive number does not exist
+  MEGA65_H_ERR_NAME_TOO_LONG = 0x81,      ///< Filename >63 characters
+  MEGA65_H_ERR_NOT_IMPLEMENTED = 0x82,    ///< Service not implemented
+  MEGA65_H_ERR_FILE_TOO_LONG = 0x83,      ///< File >16MB
+  MEGA65_H_ERR_TOO_MANY_OPEN = 0x84,      ///< All file descriptors in use
+  MEGA65_H_ERR_INVALID_CLUSTER = 0x85,    ///< Invalid cluster number
+  MEGA65_H_ERR_IS_DIRECTORY = 0x86,       ///< Expected file, got directory
+  MEGA65_H_ERR_NOT_DIRECTORY = 0x87,      ///< Expected directory, got file
+  MEGA65_H_ERR_FILE_NOT_FOUND = 0x88,     ///< File not found
+  MEGA65_H_ERR_INVALID_FD = 0x89,         ///< Invalid file descriptor
+  MEGA65_H_ERR_IMAGE_WRONG_LENGTH = 0x8A, ///< Disk image wrong size
+  MEGA65_H_ERR_IMAGE_FRAGMENTED = 0x8B,   ///< Disk image not contiguous
+  MEGA65_H_ERR_NO_SPACE = 0x8C,           ///< No free space on SD card
+  MEGA65_H_ERR_FILE_EXISTS = 0x8D,        ///< File already exists
+  MEGA65_H_ERR_DIRECTORY_FULL = 0x8E,     ///< Directory full
+  MEGA65_H_ERR_DOUBLE_ATTACH = 0x8F,      ///< Image already attached
+  MEGA65_H_EOF = 0xFF,                    ///< End of file/directory
+} mega65_h_err;
+
+/// FAT directory entry returned by mega65_h_readdir().
+/// Total size: 87 bytes. Buffer must be 256-byte aligned.
+typedef struct {
+  char long_name[64];     ///< Long filename, null-terminated (max 63 chars)
+  uint8_t name_len;       ///< Length of long filename
+  char short_name[11];    ///< 8.3 filename (space-padded, no dot/null)
+  uint8_t _reserved[2];   ///< Reserved
+  uint32_t start_cluster; ///< Starting cluster number
+  uint32_t file_size;     ///< File size in bytes
+  uint8_t attributes;     ///< Attribute flags (MEGA65_H_ATTR_*)
+} mega65_h_dirent;
+
+/// File attribute flags for mega65_h_dirent.attributes.
+enum
+#ifdef __clang__
+    : uint8_t
+#endif
+{
+  MEGA65_H_ATTR_READONLY = 0x01, ///< Read-only file
+  MEGA65_H_ATTR_HIDDEN = 0x02,   ///< Hidden file
+  MEGA65_H_ATTR_SYSTEM = 0x04,   ///< System file
+  MEGA65_H_ATTR_VOLLABEL = 0x08, ///< Volume label
+  MEGA65_H_ATTR_SUBDIR = 0x10,   ///< Sub-directory
+  MEGA65_H_ATTR_ARCHIVE = 0x20,  ///< Archive flag
+};
+
+/// Hyppo/HDOS version information returned by mega65_h_getversion().
+typedef struct {
+  uint8_t hyppo_major; ///< Hyppo version major
+  uint8_t hyppo_minor; ///< Hyppo version minor
+  uint8_t hdos_major;  ///< HDOS version major
+  uint8_t hdos_minor;  ///< HDOS version minor
+} mega65_h_version;
+
+/// Flags for mega65_h_attach().
+enum
+#ifdef __clang__
+    : uint8_t
+#endif
+{
+  MEGA65_H_ATTACH_D0 = 0x00,  ///< Attach to drive 0
+  MEGA65_H_ATTACH_D1 = 0x01,  ///< Attach to drive 1
+  MEGA65_H_DETACH_D0 = 0x80,  ///< Detach drive 0
+  MEGA65_H_DETACH_D1 = 0x81,  ///< Detach drive 1
+  MEGA65_H_DETACH_ALL = 0xC2, ///< Detach both drives
+};
+
+// --- System services ---
+
+/// Get Hyppo and HDOS version numbers.
+///
+/// @return Hyppo and HDOS major/minor versions
+mega65_h_version mega65_h_getversion(void) __attribute__((leaf));
+
+/// Get the error code from the last failed Hyppo service call.
+/// Only valid if the previous call returned a nonzero error.
+///
+/// @return Error code from the last failed service
+mega65_h_err mega65_h_geterrorcode(void) __attribute__((leaf));
+
+// --- Drive services ---
+
+/// Get the currently selected SD card drive number.
+///
+/// @return Current drive number
+uint8_t mega65_h_getcurrentdrive(void) __attribute__((leaf));
+
+/// Get the default SD card drive number (set at boot).
+///
+/// @return Default drive number
+uint8_t mega65_h_getdefaultdrive(void) __attribute__((leaf));
+
+/// Select the active SD card drive/partition.
+///
+/// @param drive  Drive number
+/// @return MEGA65_H_OK or error code
+mega65_h_err mega65_h_selectdrive(uint8_t drive) __attribute__((leaf));
+
+// --- Filename and file search ---
+
+/// Set the Hyppo filename for subsequent find/load operations.
+/// Filename is ASCII (not PETSCII), null-terminated, max 63 characters.
+///
+/// Staged in the page the linker script gives as __mega65_h_name_buf, which
+/// this platform's script puts at $0100 -- the bottom of the hardware stack,
+/// far below where compiled code reaches. Move it with
+///
+///   -Wl,--defsym=__mega65_h_name_buf=0x0400
+///
+/// @param filename  ASCII filename string
+/// @return MEGA65_H_OK or error code
+mega65_h_err mega65_h_setname(const char *filename) __attribute__((leaf));
+
+/// Name a filename buffer the caller has already filled in.
+///
+/// Hyppo copies a whole page and reads only its high byte, so a buffer is
+/// named by page. Use this when the program owns the page: two names at once
+/// need two pages, and a program loading a file over itself needs the name to
+/// outlive the page it came from.
+///
+/// @param page  High byte of a page-aligned 256-byte buffer below $7F00,
+///              holding the null-terminated ASCII name
+/// @return MEGA65_H_OK, or MEGA65_H_ERR_INVALID_ADDRESS for a page at or
+///         above $7F
+mega65_h_err mega65_h_setname_page(uint8_t page) __attribute__((leaf));
+
+/*** Freeze-slot services (syspart trap $D642) ***/
+
+/// These use $D642, the system-partition trap, where every other mega65_h_
+/// function here uses $D640. All of them need a system partition on the SD
+/// card; without one, the machine reports no slots.
+
+/// First sector of a freeze slot.
+///
+/// Check the slot against mega65_h_get_freeze_slot_count() first. Hyppo's own
+/// range check does not work, and this trap cannot report a bad slot.
+///
+/// @param slot  Freeze slot number
+/// @return Sector number, or anything at all if the slot is out of range
+uint32_t mega65_h_locate_freezeslot(uint16_t slot) __attribute__((leaf));
+
+/// Replace the running program with the one held in a freeze slot.
+///
+/// Control does not come back if this succeeds: hyppo restores the frozen
+/// program over this one, so code after the call runs only on failure.
+///
+/// Hyppo restores only X on entry to this trap, because its own dispatch
+/// clobbers X and leaves Y alone: the low byte reaches it in Y untouched.
+///
+/// @param slot  Freeze slot number
+void mega65_h_unfreeze_from_slot(uint16_t slot) __attribute__((leaf));
+
+/// Copy hyppo's list of memory regions a freeze covers.
+///
+/// @param dest  Buffer below $8000; a higher address quietly lands 32KB
+///              lower instead of being refused
+/// @return MEGA65_H_OK
+mega65_h_err mega65_h_read_freeze_region_list(void *dest) __attribute__((leaf));
+
+/// Number of freeze slots the system partition holds.
+///
+/// @return Slot count, or 0 if there is no system partition
+uint16_t mega65_h_get_freeze_slot_count(void) __attribute__((leaf));
+
+/// Copy the running program's 256-byte task descriptor into a page.
+///
+/// Says which disk images are mounted, among other task state. Hyppo copies
+/// a whole page, so the buffer is named by page.
+///
+/// @param page  High byte of a page-aligned 256-byte buffer below $7F00
+/// @return MEGA65_H_OK, or MEGA65_H_ERR_INVALID_ADDRESS for a page at or
+///         above $7F
+mega65_h_err mega65_h_get_proc_desc(uint8_t page) __attribute__((leaf));
+
+/// Find a file by name in the current directory.
+/// Precondition: mega65_h_setname() called with the target filename.
+/// On success, the internal FAT directory entry is set for use by
+/// mega65_h_openfile(), mega65_h_chdir(), or mega65_h_rmfile().
+///
+/// @return MEGA65_H_OK or error code (MEGA65_H_ERR_FILE_NOT_FOUND)
+mega65_h_err mega65_h_findfile(void) __attribute__((leaf));
+
+/// Begin searching for files matching the name set by mega65_h_setname().
+/// Returns a directory file descriptor for use with mega65_h_findnext().
+/// Caller must close with mega65_h_closedir() unless findnext exhausts
+/// the search (auto-closes on MEGA65_H_ERR_FILE_NOT_FOUND).
+///
+/// @param fd  Pointer to receive the directory file descriptor
+/// @return MEGA65_H_OK or error code
+mega65_h_err mega65_h_findfirst(uint8_t *fd) __attribute__((leaf));
+
+/// Find the next matching file after mega65_h_findfirst().
+/// Auto-closes the fd on MEGA65_H_ERR_FILE_NOT_FOUND.
+///
+/// @return MEGA65_H_OK or error code
+mega65_h_err mega65_h_findnext(void) __attribute__((leaf));
+
+// --- File I/O ---
+// readfile/writefile operate on the "current file" set by openfile.
+// Data is transferred via the Hyppo sector buffer at $FFD6E00-$FFD6FFF.
+// Use DMA or 32-bit addressing to access the sector buffer.
+
+/// Open a file for reading/writing.
+/// Precondition: file found via findfile/findfirst/findnext/readdir.
+/// Sets the file as the "current file" for readfile/writefile.
+///
+/// Acts on the dirent left by the last search. A search that matched nothing
+/// does not clear that dirent, so this still succeeds and reopens the file
+/// found before it — check the search result yourself.
+///
+/// @param fd  Pointer to receive the file descriptor (for closefile)
+/// @return MEGA65_H_OK or error code
+mega65_h_err mega65_h_openfile(uint8_t *fd) __attribute__((leaf));
+
+/// Hyppo's 512-byte sector buffer, which readfile and writefile transfer
+/// through. A 28-bit address: reach it with DMA or 32-bit addressing, not an
+/// ordinary pointer.
+#define MEGA65_H_SECTOR_BUFFER 0xFFD6E00UL
+
+/// Read the next sector of the current file into MEGA65_H_SECTOR_BUFFER.
+/// End of file gives MEGA65_H_OK with a count of 0, and *count is always
+/// written, so a loop can rely on it.
+///
+/// @param count  Pointer to receive bytes read (0 = EOF)
+/// @return MEGA65_H_OK or error code
+mega65_h_err mega65_h_readfile(uint16_t *count) __attribute__((leaf));
+
+/// Write the sector buffer to the current file (WRITEFILE).
+/// The file must have been created by mega65_h_mkfile() and opened.
+/// *count is written on every path, so it is safe to loop on.
+///
+/// @param count  Pointer to receive bytes written
+/// @return MEGA65_H_OK or error code
+mega65_h_err mega65_h_writefile(uint16_t *count) __attribute__((leaf));
+
+/// Create a file of the given size (MKFILE), named by mega65_h_setname().
+/// Hyppo's limitations, not this wrapper's: 8.3 names only, current directory
+/// only, space allocated contiguously so the file can be mounted as an image,
+/// 16 MB ceiling, and a filesystem without room is not reported cleanly.
+///
+/// @param size  File size in bytes, up to 16 MB
+/// @return MEGA65_H_OK or error code
+mega65_h_err mega65_h_mkfile(uint32_t size) __attribute__((leaf));
+
+/// Allow writes to the attached D81 image (D81WRITE_EN).
+/// Attaching with mega65_h_attach() alone leaves the image read-only.
+///
+/// @return MEGA65_H_OK or error code
+mega65_h_err mega65_h_d81write_en(void) __attribute__((leaf));
+
+/// Close a file descriptor.
+///
+/// @param fd  File descriptor from mega65_h_openfile()
+void mega65_h_closefile(uint8_t fd) __attribute__((leaf));
+
+/// Close all open file and directory descriptors.
+void mega65_h_closeall(void) __attribute__((leaf));
+
+/// Delete a file.
+/// Precondition: file found via findfile/findfirst/findnext/readdir.
+///
+/// @return MEGA65_H_OK or error code
+mega65_h_err mega65_h_rmfile(void) __attribute__((leaf));
+
+// --- Directory I/O ---
+
+/// Open the current working directory for reading.
+///
+/// @param fd  Pointer to receive the directory file descriptor
+/// @return MEGA65_H_OK or error code
+mega65_h_err mega65_h_opendir(uint8_t *fd) __attribute__((leaf));
+
+/// Read the next directory entry.
+/// dest must be 256-byte aligned and below $7F00: Hyppo takes only a page
+/// number and rejects pages $7F and above, so a buffer the linker happened to
+/// place higher fails at run time with MEGA65_H_ERR_INVALID_ADDRESS.
+/// Returns MEGA65_H_EOF when no more entries remain.
+///
+/// @param fd    Directory file descriptor from mega65_h_opendir()
+/// @param dest  Page-aligned buffer to receive the FAT directory entry
+/// @return MEGA65_H_OK, MEGA65_H_EOF, or error code
+mega65_h_err mega65_h_readdir(uint8_t fd, mega65_h_dirent *dest)
+    __attribute__((leaf));
+
+/// Close a directory file descriptor.
+///
+/// @param fd  File descriptor from mega65_h_opendir()
+void mega65_h_closedir(uint8_t fd) __attribute__((leaf));
+
+/// Change to a subdirectory.
+/// Precondition: directory found via findfile/findfirst/findnext/readdir.
+/// Use ".." entry to go up one level.
+///
+/// @return MEGA65_H_OK or error code (MEGA65_H_ERR_NOT_DIRECTORY)
+mega65_h_err mega65_h_chdir(void) __attribute__((leaf));
+
+/// Change to the root directory of a drive.
+///
+/// @param drive  Drive number
+/// @return MEGA65_H_OK or error code
+mega65_h_err mega65_h_cdrootdir(uint8_t drive) __attribute__((leaf));
+
+// --- File loading (bypasses sector buffer) ---
+
+/// Load a file from the SD card into chip memory at a 28-bit address.
+/// Call mega65_h_setname() first. Loads the entire file at once.
+///
+/// @param addr  28-bit destination in chip memory ($000000-$FFFFFF)
+/// @return MEGA65_H_OK or error code
+mega65_h_err mega65_h_loadfile(uint32_t addr) __attribute__((leaf));
+
+/// Load a file from the SD card into attic/hyper RAM.
+/// Call mega65_h_setname() first. Loads the entire file at once.
+///
+/// @param addr  24-bit offset in attic RAM (base $08000000 added by hardware)
+/// @return MEGA65_H_OK or error code
+mega65_h_err mega65_h_loadfile_attic(uint32_t addr) __attribute__((leaf));
+
+// --- Disk image services ---
+
+/// Attach or detach a D81 disk image to an F011 floppy drive.
+/// For attach: call mega65_h_setname() with the image filename first.
+/// flags: MEGA65_H_ATTACH_D0, MEGA65_H_ATTACH_D1, MEGA65_H_DETACH_D0,
+///        MEGA65_H_DETACH_D1, MEGA65_H_DETACH_ALL.
+///
+/// @param flags  Attach/detach flags
+/// @return MEGA65_H_OK or error code
+mega65_h_err mega65_h_attach(uint8_t flags) __attribute__((leaf));
 
 #ifdef __clang__
 #pragma clang diagnostic pop

--- a/mos-platform/mega65/mega65_h_attach.c
+++ b/mos-platform/mega65/mega65_h_attach.c
@@ -1,0 +1,28 @@
+// Copyright 2026 LLVM-MOS Project
+// Licensed under the Apache License, Version 2.0 with LLVM Exceptions.
+// See https://github.com/llvm-mos/llvm-mos-sdk/blob/main/LICENSE for license
+// information.
+
+// Virtualises the F011 floppy controller with D81 images from SD card.
+// Drive 0 = unit 8, drive 1 = unit 9 (by default).
+//
+// Trap $D640: attach ($4A).
+// For attach: call mega65_h_setname() with the image filename first.
+// Cannot open files inside disk images -- use KERNAL/F011 for that.
+
+#include <mega65.h>
+
+mega65_h_err mega65_h_attach(uint8_t flags) {
+  uint8_t err;
+  // Carry consumed inside the block; see mega65_k_load.c for why.
+  asm volatile("lda #$4a\n"
+               "sta $d640\n"
+               "clv\n"
+               "bcc 1f\n"
+               "lda #0\n"
+               "1:\n"
+               : "=a"(err), "+x"(flags)
+               :
+               : "y", "p");
+  return err;
+}

--- a/mos-platform/mega65/mega65_h_d81write_en.c
+++ b/mos-platform/mega65/mega65_h_d81write_en.c
@@ -1,0 +1,22 @@
+// Copyright 2026 LLVM-MOS Project
+// Licensed under the Apache License, Version 2.0 with LLVM Exceptions.
+// See https://github.com/llvm-mos/llvm-mos-sdk/blob/main/LICENSE for license
+// information.
+
+// Trap $D640: d81write_en ($44).
+
+#include <mega65.h>
+
+mega65_h_err mega65_h_d81write_en(void) {
+  uint8_t err;
+  asm volatile("lda #$44\n"
+               "sta $d640\n"
+               "clv\n"
+               "bcc 1f\n"
+               "lda #0\n"
+               "1:\n"
+               : "=a"(err)
+               :
+               : "x", "y", "p");
+  return err;
+}

--- a/mos-platform/mega65/mega65_h_dirio.c
+++ b/mos-platform/mega65/mega65_h_dirio.c
@@ -1,0 +1,82 @@
+// Copyright 2026 LLVM-MOS Project
+// Licensed under the Apache License, Version 2.0 with LLVM Exceptions.
+// See https://github.com/llvm-mos/llvm-mos-sdk/blob/main/LICENSE for license
+// information.
+
+// Trap $D640: opendir ($12), readdir ($14), closedir ($16),
+// chdir ($0C), cdrootdir ($3C).
+//
+// Success is C=1, error code in A. The carry is consumed inside each asm
+// block; see mega65_k_load.c for why an "=c" output cannot be used.
+
+#include <mega65.h>
+
+mega65_h_err mega65_h_opendir(uint8_t *fd) {
+  uint8_t result, ok;
+  asm volatile("lda #$12\n"
+               "sta $d640\n"
+               "clv\n"
+               "ldx #0\n"
+               "bcc 1f\n"
+               "inx\n"
+               "1:\n"
+               : "=a"(result), "=x"(ok)
+               :
+               : "y", "p");
+  if (!ok)
+    return result;
+  *fd = result;
+  return 0;
+}
+
+mega65_h_err mega65_h_readdir(uint8_t fd, mega65_h_dirent *dest) {
+  uint8_t page = (uint16_t)dest >> 8;
+  uint8_t err;
+  asm volatile("lda #$14\n"
+               "sta $d640\n"
+               "clv\n"
+               "bcc 1f\n"
+               "lda #0\n"
+               "1:\n"
+               : "=a"(err), "+x"(fd), "+y"(page)
+               :
+               : "p");
+  return err;
+}
+
+void mega65_h_closedir(uint8_t fd) {
+  asm volatile("lda #$16\n"
+               "sta $d640\n"
+               "clv\n"
+               : "+x"(fd)
+               :
+               : "a", "y", "p");
+}
+
+mega65_h_err mega65_h_chdir(void) {
+  uint8_t err;
+  asm volatile("lda #$0c\n"
+               "sta $d640\n"
+               "clv\n"
+               "bcc 1f\n"
+               "lda #0\n"
+               "1:\n"
+               : "=a"(err)
+               :
+               : "x", "y", "p");
+  return err;
+}
+
+mega65_h_err mega65_h_cdrootdir(uint8_t drive) {
+  uint8_t err;
+  asm volatile("lda #$3c\n"
+               "sta $d640\n"
+               "clv\n"
+               "bcc 1f\n"
+               "lda #0\n"
+               "1:\n"
+               : "=a"(err), "+x"(drive)
+               :
+               : "y", "p");
+  return err;
+}

--- a/mos-platform/mega65/mega65_h_drive.c
+++ b/mos-platform/mega65/mega65_h_drive.c
@@ -1,0 +1,47 @@
+// Copyright 2026 LLVM-MOS Project
+// Licensed under the Apache License, Version 2.0 with LLVM Exceptions.
+// See https://github.com/llvm-mos/llvm-mos-sdk/blob/main/LICENSE for license
+// information.
+
+// "Drives" in Hyppo are SD card partitions, not F011 floppy drives.
+//
+// Trap $D640: getcurrentdrive ($04), getdefaultdrive ($02), selectdrive ($06).
+
+#include <mega65.h>
+
+uint8_t mega65_h_getcurrentdrive(void) {
+  uint8_t drive;
+  asm volatile("lda #$04\n"
+               "sta $d640\n"
+               "clv\n"
+               : "=a"(drive)
+               :
+               : "x", "y", "p");
+  return drive;
+}
+
+uint8_t mega65_h_getdefaultdrive(void) {
+  uint8_t drive;
+  asm volatile("lda #$02\n"
+               "sta $d640\n"
+               "clv\n"
+               : "=a"(drive)
+               :
+               : "x", "y", "p");
+  return drive;
+}
+
+mega65_h_err mega65_h_selectdrive(uint8_t drive) {
+  uint8_t err;
+  // Carry consumed inside the block; see mega65_k_load.c for why.
+  asm volatile("lda #$06\n"
+               "sta $d640\n"
+               "clv\n"
+               "bcc 1f\n"
+               "lda #0\n"
+               "1:\n"
+               : "=a"(err), "+x"(drive)
+               :
+               : "y", "p");
+  return err;
+}

--- a/mos-platform/mega65/mega65_h_fileio.c
+++ b/mos-platform/mega65/mega65_h_fileio.c
@@ -1,0 +1,92 @@
+// Copyright 2026 LLVM-MOS Project
+// Licensed under the Apache License, Version 2.0 with LLVM Exceptions.
+// See https://github.com/llvm-mos/llvm-mos-sdk/blob/main/LICENSE for license
+// information.
+
+// readfile/writefile operate on the "current file" set by openfile.
+// Data is transferred via the Hyppo sector buffer at $FFD6E00-$FFD6FFF.
+//
+// Trap $D640: openfile ($18), readfile ($1A), closefile ($20),
+// closeall ($22), rmfile ($26).
+//
+// Success is C=1, error code in A. The carry is consumed inside each asm
+// block; see mega65_k_load.c for why an "=c" output cannot be used.
+
+#include <mega65.h>
+
+mega65_h_err mega65_h_openfile(uint8_t *fd) {
+  uint8_t result, ok;
+  asm volatile("lda #$18\n"
+               "sta $d640\n"
+               "clv\n"
+               "ldx #0\n"
+               "bcc 1f\n"
+               "inx\n"
+               "1:\n"
+               : "=a"(result), "=x"(ok)
+               :
+               : "y", "p");
+  if (!ok)
+    return result;
+  *fd = result;
+  return 0;
+}
+
+mega65_h_err mega65_h_readfile(uint16_t *count) {
+  uint8_t err, lo, hi, ok;
+  // End of file is reported as a failure with A=0 and a zero byte count, so
+  // the count must be written on both paths for the caller's 0-means-EOF
+  // test to work. A already holds the error code, so the carry is turned into
+  // a value around it rather than in it.
+  asm volatile("lda #$1a\n"
+               "sta $d640\n"
+               "clv\n"
+               "pha\n"
+               "lda #0\n"
+               "bcc 1f\n"
+               "lda #1\n"
+               "1:\n"
+               "sta %[ok]\n"
+               "pla\n"
+               : "=a"(err), "=x"(lo), "=y"(hi), [ok] "=&r"(ok)
+               :
+               : "p");
+  if (!ok) {
+    *count = 0;
+    return err;
+  }
+  *count = ((uint16_t)hi << 8) | lo;
+  return 0;
+}
+
+void mega65_h_closefile(uint8_t fd) {
+  asm volatile("lda #$20\n"
+               "sta $d640\n"
+               "clv\n"
+               : "+x"(fd)
+               :
+               : "a", "y", "p");
+}
+
+void mega65_h_closeall(void) {
+  asm volatile("lda #$22\n"
+               "sta $d640\n"
+               "clv\n"
+               :
+               :
+               : "a", "x", "y", "p");
+}
+
+mega65_h_err mega65_h_rmfile(void) {
+  uint8_t err;
+  asm volatile("lda #$26\n"
+               "sta $d640\n"
+               "clv\n"
+               "bcc 1f\n"
+               "lda #0\n"
+               "1:\n"
+               : "=a"(err)
+               :
+               : "x", "y", "p");
+  return err;
+}

--- a/mos-platform/mega65/mega65_h_findfile.c
+++ b/mos-platform/mega65/mega65_h_findfile.c
@@ -1,0 +1,58 @@
+// Copyright 2026 LLVM-MOS Project
+// Licensed under the Apache License, Version 2.0 with LLVM Exceptions.
+// See https://github.com/llvm-mos/llvm-mos-sdk/blob/main/LICENSE for license
+// information.
+
+// Trap $D640: findfile ($34), findfirst ($30), findnext ($32).
+// All require mega65_h_setname() to be called first.
+//
+// Success is C=1, error code in A. The carry is consumed inside each asm
+// block; see mega65_k_load.c for why an "=c" output cannot be used.
+
+#include <mega65.h>
+
+mega65_h_err mega65_h_findfile(void) {
+  uint8_t err;
+  asm volatile("lda #$34\n"
+               "sta $d640\n"
+               "clv\n"
+               "bcc 1f\n"
+               "lda #0\n"
+               "1:\n"
+               : "=a"(err)
+               :
+               : "x", "y", "p");
+  return err;
+}
+
+mega65_h_err mega65_h_findfirst(uint8_t *fd) {
+  uint8_t result, ok;
+  asm volatile("lda #$30\n"
+               "sta $d640\n"
+               "clv\n"
+               "ldx #0\n"
+               "bcc 1f\n"
+               "inx\n"
+               "1:\n"
+               : "=a"(result), "=x"(ok)
+               :
+               : "y", "p");
+  if (!ok)
+    return result;
+  *fd = result;
+  return 0;
+}
+
+mega65_h_err mega65_h_findnext(void) {
+  uint8_t err;
+  asm volatile("lda #$32\n"
+               "sta $d640\n"
+               "clv\n"
+               "bcc 1f\n"
+               "lda #0\n"
+               "1:\n"
+               : "=a"(err)
+               :
+               : "x", "y", "p");
+  return err;
+}

--- a/mos-platform/mega65/mega65_h_get_freeze_slot_count.c
+++ b/mos-platform/mega65/mega65_h_get_freeze_slot_count.c
@@ -1,0 +1,25 @@
+// Copyright 2026 LLVM-MOS Project
+// Licensed under the Apache License, Version 2.0 with LLVM Exceptions.
+// See https://github.com/llvm-mos/llvm-mos-sdk/blob/main/LICENSE for license
+// information.
+
+// Trap $D642 (syspart): get_slot_count ($16).
+//
+// See mega65_h_locate_freezeslot.c on why the trap register differs.
+
+#include <mega65.h>
+
+uint16_t mega65_h_get_freeze_slot_count(void) {
+  uint8_t count_lo, count_hi;
+
+  // Count in X and Y, low first. No failure report: a machine without a
+  // system partition answers zero.
+  asm volatile("lda #$16\n"
+               "sta $d642\n"
+               "clv\n"
+               : "=x"(count_lo), "=y"(count_hi)
+               :
+               : "a", "p");
+
+  return (uint16_t)count_lo | ((uint16_t)count_hi << 8);
+}

--- a/mos-platform/mega65/mega65_h_get_proc_desc.c
+++ b/mos-platform/mega65/mega65_h_get_proc_desc.c
@@ -1,0 +1,27 @@
+// Copyright 2026 LLVM-MOS Project
+// Licensed under the Apache License, Version 2.0 with LLVM Exceptions.
+// See https://github.com/llvm-mos/llvm-mos-sdk/blob/main/LICENSE for license
+// information.
+
+// Copies the running program's task descriptor out to a page the caller names.
+//
+// Trap $D640: get_proc_desc ($48).
+
+#include <mega65.h>
+
+mega65_h_err mega65_h_get_proc_desc(uint8_t page) {
+  uint8_t err;
+  // Carry consumed inside the block; see mega65_k_load.c for why.
+  //
+  // "memory" because hyppo writes the page where the compiler cannot see.
+  asm volatile("lda #$48\n"
+               "sta $d640\n"
+               "clv\n"
+               "bcc 1f\n"
+               "lda #0\n"
+               "1:\n"
+               : "=a"(err), "+y"(page)
+               :
+               : "x", "p", "memory");
+  return err;
+}

--- a/mos-platform/mega65/mega65_h_geterrorcode.c
+++ b/mos-platform/mega65/mega65_h_geterrorcode.c
@@ -1,0 +1,19 @@
+// Copyright 2026 LLVM-MOS Project
+// Licensed under the Apache License, Version 2.0 with LLVM Exceptions.
+// See https://github.com/llvm-mos/llvm-mos-sdk/blob/main/LICENSE for license
+// information.
+
+// Trap $D640: geterrorcode ($38).
+
+#include <mega65.h>
+
+mega65_h_err mega65_h_geterrorcode(void) {
+  uint8_t err;
+  asm volatile("lda #$38\n"
+               "sta $d640\n"
+               "clv\n"
+               : "=a"(err)
+               :
+               : "x", "y", "p");
+  return err;
+}

--- a/mos-platform/mega65/mega65_h_getversion.c
+++ b/mos-platform/mega65/mega65_h_getversion.c
@@ -1,0 +1,33 @@
+// Copyright 2026 LLVM-MOS Project
+// Licensed under the Apache License, Version 2.0 with LLVM Exceptions.
+// See https://github.com/llvm-mos/llvm-mos-sdk/blob/main/LICENSE for license
+// information.
+
+// Trap $D640: getversion ($00).
+
+#include <mega65.h>
+
+mega65_h_version mega65_h_getversion(void) {
+  uint8_t hyppo_major, hyppo_minor, hdos_major, hdos_minor;
+  // getversion is the one service that answers in all four registers. The
+  // fourth has to be moved out of Z before returning to compiled code, and A
+  // is already spoken for, hence the pha/pla. Register outputs only: an "=m"
+  // operand silently addresses the wrong memory once a local lands on the
+  // soft stack.
+  asm volatile("lda #$00\n"
+               "sta $d640\n"
+               "clv\n"
+               "pha\n"
+               "tza\n"
+               "sta %[dosmin]\n"
+               "ldz #0\n"
+               "pla\n"
+               : "=a"(hyppo_major), "=x"(hyppo_minor),
+                 "=y"(hdos_major), [dosmin] "=&r"(hdos_minor)
+               :
+               : "p");
+  return (mega65_h_version){.hyppo_major = hyppo_major,
+                            .hyppo_minor = hyppo_minor,
+                            .hdos_major = hdos_major,
+                            .hdos_minor = hdos_minor};
+}

--- a/mos-platform/mega65/mega65_h_loadfile.c
+++ b/mos-platform/mega65/mega65_h_loadfile.c
@@ -1,0 +1,57 @@
+// Copyright 2026 LLVM-MOS Project
+// Licensed under the Apache License, Version 2.0 with LLVM Exceptions.
+// See https://github.com/llvm-mos/llvm-mos-sdk/blob/main/LICENSE for license
+// information.
+
+// Bypasses KERNAL entirely. Operates on the SD card FAT filesystem,
+// not D81 disk images. No MAP state interaction: safe for use with banking.
+//
+// Trap $D640: loadfile ($36), loadfile_attic ($3E).
+//
+// Success is C=1, error code in A. The carry is consumed inside each asm
+// block; see mega65_k_load.c for why an "=c" output cannot be used.
+//
+// The destination address is passed in X/Y/Z, so Z has to be restored to 0
+// before returning to compiled code.
+
+#include <mega65.h>
+
+mega65_h_err mega65_h_loadfile(uint32_t addr) {
+  uint8_t addr_lo = (uint8_t)(addr);
+  uint8_t addr_mid = (uint8_t)(addr >> 8);
+  uint8_t addr_hi = (uint8_t)(addr >> 16);
+  uint8_t err;
+
+  asm volatile("ldz %[hi]\n"
+               "lda #$36\n"
+               "sta $d640\n"
+               "clv\n"
+               "ldz #0\n"
+               "bcc 1f\n"
+               "lda #0\n"
+               "1:\n"
+               : "=a"(err), "+x"(addr_lo), "+y"(addr_mid)
+               : [hi] "r"(addr_hi)
+               : "p");
+  return err;
+}
+
+mega65_h_err mega65_h_loadfile_attic(uint32_t addr) {
+  uint8_t addr_lo = (uint8_t)(addr);
+  uint8_t addr_mid = (uint8_t)(addr >> 8);
+  uint8_t addr_hi = (uint8_t)(addr >> 16);
+  uint8_t err;
+
+  asm volatile("ldz %[hi]\n"
+               "lda #$3e\n"
+               "sta $d640\n"
+               "clv\n"
+               "ldz #0\n"
+               "bcc 1f\n"
+               "lda #0\n"
+               "1:\n"
+               : "=a"(err), "+x"(addr_lo), "+y"(addr_mid)
+               : [hi] "r"(addr_hi)
+               : "p");
+  return err;
+}

--- a/mos-platform/mega65/mega65_h_locate_freezeslot.c
+++ b/mos-platform/mega65/mega65_h_locate_freezeslot.c
@@ -1,0 +1,36 @@
+// Copyright 2026 LLVM-MOS Project
+// Licensed under the Apache License, Version 2.0 with LLVM Exceptions.
+// See https://github.com/llvm-mos/llvm-mos-sdk/blob/main/LICENSE for license
+// information.
+
+// Trap $D642 (syspart): locate_freezeslot ($10).
+//
+// The address picks the handler, so $D642 numbers its functions separately
+// from the $D640 used elsewhere here.
+
+#include <mega65.h>
+
+/// Where hyppo leaves the sector number. Little-endian, matching uint32_t.
+#define SD_SECTOR_NUMBER 0xd681
+
+uint32_t mega65_h_locate_freezeslot(uint16_t slot) {
+  uint8_t slot_lo = (uint8_t)slot;
+  uint8_t slot_hi = (uint8_t)(slot >> 8);
+
+  // Low byte in Y, against hyppo's own comment: it pushes X then Y and pops
+  // with plx/ply, so Y comes back first and becomes the low byte. Follow the
+  // arithmetic, which decides the answer.
+  //
+  // No carry to read: this trap leaves the caller's flags alone, so a bad
+  // slot looks like a good one.
+  //
+  // "memory" because the answer lands in I/O the compiler cannot see.
+  asm volatile("lda #$10\n"
+               "sta $d642\n"
+               "clv\n"
+               :
+               : "y"(slot_lo), "x"(slot_hi)
+               : "a", "p", "memory");
+
+  return *(const volatile uint32_t *)SD_SECTOR_NUMBER;
+}

--- a/mos-platform/mega65/mega65_h_mkfile.c
+++ b/mos-platform/mega65/mega65_h_mkfile.c
@@ -1,0 +1,29 @@
+// Copyright 2026 LLVM-MOS Project
+// Licensed under the Apache License, Version 2.0 with LLVM Exceptions.
+// See https://github.com/llvm-mos/llvm-mos-sdk/blob/main/LICENSE for license
+// information.
+
+// Trap $D640: mkfile ($1E).
+
+#include <mega65.h>
+
+mega65_h_err mega65_h_mkfile(uint32_t size) {
+  uint8_t size_lo = (uint8_t)size;
+  uint8_t size_mid = (uint8_t)(size >> 8);
+  uint8_t size_hi = (uint8_t)(size >> 16);
+  uint8_t err;
+  // The size travels in X/Y/Z, so Z has to be restored to 0 before returning
+  // to compiled code.
+  asm volatile("ldz %[hi]\n"
+               "lda #$1e\n"
+               "sta $d640\n"
+               "clv\n"
+               "ldz #0\n"
+               "bcc 1f\n"
+               "lda #0\n"
+               "1:\n"
+               : "=a"(err), "+x"(size_lo), "+y"(size_mid)
+               : [hi] "r"(size_hi)
+               : "p");
+  return err;
+}

--- a/mos-platform/mega65/mega65_h_read_freeze_region_list.c
+++ b/mos-platform/mega65/mega65_h_read_freeze_region_list.c
@@ -1,0 +1,32 @@
+// Copyright 2026 LLVM-MOS Project
+// Licensed under the Apache License, Version 2.0 with LLVM Exceptions.
+// See https://github.com/llvm-mos/llvm-mos-sdk/blob/main/LICENSE for license
+// information.
+
+// Trap $D642 (syspart): read_freeze_region_list ($14).
+//
+// See mega65_h_locate_freezeslot.c on why the trap register differs.
+
+#include <mega65.h>
+
+mega65_h_err mega65_h_read_freeze_region_list(void *dest) {
+  uint8_t dest_lo = (uint8_t)(uint16_t)dest;
+  uint8_t dest_hi = (uint8_t)((uint16_t)dest >> 8);
+  uint8_t err;
+
+  // A full address, not a page. Hyppo clears the top bit to keep the copy
+  // away from its own memory, so $8000 and up quietly land 32KB lower.
+  //
+  // Carry consumed inside the block; see mega65_k_load.c for why. "memory"
+  // because hyppo writes where the compiler cannot see.
+  asm volatile("lda #$14\n"
+               "sta $d642\n"
+               "clv\n"
+               "bcc 1f\n"
+               "lda #0\n"
+               "1:\n"
+               : "=a"(err)
+               : "x"(dest_lo), "y"(dest_hi)
+               : "p", "memory");
+  return err;
+}

--- a/mos-platform/mega65/mega65_h_setname.c
+++ b/mos-platform/mega65/mega65_h_setname.c
@@ -1,0 +1,32 @@
+// Copyright 2026 LLVM-MOS Project
+// Licensed under the Apache License, Version 2.0 with LLVM Exceptions.
+// See https://github.com/llvm-mos/llvm-mos-sdk/blob/main/LICENSE for license
+// information.
+
+// Stages a filename where Hyppo can read it, then names the page.
+// Shared prerequisite for loadfile, findfile, dirio, and attach workflows.
+
+#include <mega65.h>
+#include <stdint.h>
+
+/// Longest name Hyppo accepts, excluding the terminator.
+#define NAME_LEN_MAX 63
+
+/// The staging page, placed by the linker script rather than by this file:
+/// which page is free is a property of the program, not of the wrapper. A
+/// program holding two names at once -- one naming a file being loaded over
+/// itself, one naming an image still to be attached -- needs two pages and
+/// mega65_h_setname_page() for the second.
+extern char __mega65_h_name_buf[256];
+
+mega65_h_err mega65_h_setname(const char *filename) {
+  char *buf = __mega65_h_name_buf;
+  uint8_t i = 0;
+  while (filename[i] && i < NAME_LEN_MAX) {
+    buf[i] = filename[i];
+    ++i;
+  }
+  buf[i] = 0;
+
+  return mega65_h_setname_page((uint8_t)((uintptr_t)__mega65_h_name_buf >> 8));
+}

--- a/mos-platform/mega65/mega65_h_setname_page.c
+++ b/mos-platform/mega65/mega65_h_setname_page.c
@@ -1,0 +1,32 @@
+// Copyright 2026 LLVM-MOS Project
+// Licensed under the Apache License, Version 2.0 with LLVM Exceptions.
+// See https://github.com/llvm-mos/llvm-mos-sdk/blob/main/LICENSE for license
+// information.
+
+// Names an already-staged filename buffer to Hyppo.
+//
+// Trap $D640: setname ($2E).
+//
+// Its own translation unit so that a program staging its own page never links
+// mega65_h_setname()'s copy loop.
+
+#include <mega65.h>
+
+mega65_h_err mega65_h_setname_page(uint8_t page) {
+  uint8_t err;
+  // Carry consumed inside the block; see mega65_k_load.c for why.
+  //
+  // "memory" because hyppo reads the page the caller just filled, and this
+  // block inlines into that caller: volatile alone orders this against other
+  // volatile accesses, not against the plain stores that staged the name.
+  asm volatile("lda #$2e\n"
+               "sta $d640\n"
+               "clv\n"
+               "bcc 1f\n"
+               "lda #0\n"
+               "1:\n"
+               : "=a"(err), "+y"(page)
+               :
+               : "x", "p", "memory");
+  return err;
+}

--- a/mos-platform/mega65/mega65_h_unfreeze_from_slot.c
+++ b/mos-platform/mega65/mega65_h_unfreeze_from_slot.c
@@ -1,0 +1,30 @@
+// Copyright 2026 LLVM-MOS Project
+// Licensed under the Apache License, Version 2.0 with LLVM Exceptions.
+// See https://github.com/llvm-mos/llvm-mos-sdk/blob/main/LICENSE for license
+// information.
+
+// Trap $D642 (syspart): unfreeze_from_slot ($12).
+//
+// See mega65_h_locate_freezeslot.c on why the trap register differs.
+
+#include <mega65.h>
+
+void mega65_h_unfreeze_from_slot(uint16_t slot) {
+  uint8_t slot_lo = (uint8_t)slot;
+  uint8_t slot_hi = (uint8_t)(slot >> 8);
+
+  // Bytes go where mega65_h_locate_freezeslot puts them, since hyppo hands
+  // both traps to the same routine. That trap restores X and Y from the saved
+  // registers; this one restores only X, and does not need to restore Y --
+  // the trap dispatch clobbers X with tax and never touches Y, so the low byte
+  // arrives on its own.
+  //
+  // Control does not come back if this succeeds: hyppo restores the frozen
+  // program over this one, so the next line runs only on failure.
+  asm volatile("lda #$12\n"
+               "sta $d642\n"
+               "clv\n"
+               :
+               : "y"(slot_lo), "x"(slot_hi)
+               : "a", "p", "memory");
+}

--- a/mos-platform/mega65/mega65_h_writefile.c
+++ b/mos-platform/mega65/mega65_h_writefile.c
@@ -1,0 +1,33 @@
+// Copyright 2026 LLVM-MOS Project
+// Licensed under the Apache License, Version 2.0 with LLVM Exceptions.
+// See https://github.com/llvm-mos/llvm-mos-sdk/blob/main/LICENSE for license
+// information.
+
+// Trap $D640: writefile ($1C).
+
+#include <mega65.h>
+
+mega65_h_err mega65_h_writefile(uint16_t *count) {
+  uint8_t err, lo, hi, ok;
+  // The count must be written on both paths, as in mega65_h_readfile: a caller
+  // looping until it reaches zero would otherwise read a stale value.
+  asm volatile("lda #$1c\n"
+               "sta $d640\n"
+               "clv\n"
+               "pha\n"
+               "lda #0\n"
+               "bcc 1f\n"
+               "lda #1\n"
+               "1:\n"
+               "sta %[ok]\n"
+               "pla\n"
+               : "=a"(err), "=x"(lo), "=y"(hi), [ok] "=&r"(ok)
+               :
+               : "p");
+  if (!ok) {
+    *count = 0;
+    return err;
+  }
+  *count = ((uint16_t)hi << 8) | lo;
+  return 0;
+}

--- a/mos-platform/mega65/mega65_k_addkey.c
+++ b/mos-platform/mega65/mega65_k_addkey.c
@@ -1,0 +1,23 @@
+// Copyright 2026 LLVM-MOS Project
+// Licensed under the Apache License, Version 2.0 with LLVM Exceptions.
+// See https://github.com/llvm-mos/llvm-mos-sdk/blob/main/LICENSE for license
+// information.
+
+#include <mega65.h>
+
+/// Add a PETSCII character to the keyboard input buffer (ADDKEY, $FF4A).
+/// @return 0 on success, 1 if the buffer is full.
+uint8_t mega65_k_addkey(unsigned char petscii_char) {
+  uint8_t full;
+  // ADDKEY answers in the carry, which has to be consumed here: "=c" outputs
+  // miscompile (see mega65_k_load.c).
+  asm volatile("jsr __ADDKEY\n"
+               "lda #0\n"
+               "bcc 1f\n"
+               "lda #1\n"
+               "1:\n"
+               : "=a"(full)
+               : "a"(petscii_char)
+               : "x", "y", "p");
+  return full;
+}

--- a/mos-platform/mega65/mega65_k_close_all.c
+++ b/mos-platform/mega65/mega65_k_close_all.c
@@ -1,0 +1,14 @@
+// Copyright 2026 LLVM-MOS Project
+// Licensed under the Apache License, Version 2.0 with LLVM Exceptions.
+// See https://github.com/llvm-mos/llvm-mos-sdk/blob/main/LICENSE for license
+// information.
+
+#include <mega65.h>
+
+/// Close all open files on the specified device (CLOSE_ALL, $FF50).
+/// Restores default I/O channels if the current channel was on that device.
+void mega65_k_close_all(uint8_t device) {
+  // CLOSE_ALL reloads A from its own state before returning, so the device
+  // number does not survive the call.
+  asm volatile("jsr __CLOSE_ALL" : "+a"(device) : : "x", "y", "p");
+}

--- a/mos-platform/mega65/mega65_k_cmp_far.c
+++ b/mos-platform/mega65/mega65_k_cmp_far.c
@@ -1,0 +1,36 @@
+// Copyright 2026 LLVM-MOS Project
+// Licensed under the Apache License, Version 2.0 with LLVM Exceptions.
+// See https://github.com/llvm-mos/llvm-mos-sdk/blob/main/LICENSE for license
+// information.
+
+#include <mega65.h>
+
+/// Compare a byte with any MEGA65 bank via KERNAL CMP_FAR ($FF7A).
+/// @return 0 if equal, 1 if not equal.
+uint8_t mega65_k_cmp_far(uint8_t bank, uint16_t addr, uint8_t y_offset,
+                         uint8_t value) {
+  uint8_t addr_lo = (uint8_t)addr;
+  uint8_t addr_hi = (uint8_t)(addr >> 8);
+  uint8_t result;
+  // See mega65_k_lda_far.c for the $FB/$FC scratch pair and the Z handling.
+  // CMP_FAR answers in the status register, so the comparison is turned into
+  // a value here rather than through a flag output constraint.
+  asm volatile("stx $fb\n"
+               "sty $fc\n"
+               "taz\n"
+               "lda %[val]\n"
+               "ldy %[idx]\n"
+               "ldx #$fb\n"
+               "jsr __CMP_FAR\n"
+               "beq 1f\n"
+               "lda #1\n"
+               "bra 2f\n"
+               "1:\n"
+               "lda #0\n"
+               "2:\n"
+               "ldz #0\n"
+               : "=a"(result), "+x"(addr_lo), "+y"(addr_hi)
+               : "a"(bank), [idx] "r"(y_offset), [val] "r"(value)
+               : "p");
+  return result;
+}

--- a/mos-platform/mega65/mega65_k_getio.c
+++ b/mos-platform/mega65/mega65_k_getio.c
@@ -1,0 +1,12 @@
+// Copyright 2026 LLVM-MOS Project
+// Licensed under the Apache License, Version 2.0 with LLVM Exceptions.
+// See https://github.com/llvm-mos/llvm-mos-sdk/blob/main/LICENSE for license
+// information.
+
+#include <mega65.h>
+
+mega65_io_t mega65_k_getio(void) {
+  uint8_t in, out;
+  asm volatile("jsr __GETIO" : "=x"(in), "=y"(out) : : "a", "p");
+  return (mega65_io_t){.input_dev = in, .output_dev = out};
+}

--- a/mos-platform/mega65/mega65_k_getlfs.c
+++ b/mos-platform/mega65/mega65_k_getlfs.c
@@ -1,0 +1,12 @@
+// Copyright 2026 LLVM-MOS Project
+// Licensed under the Apache License, Version 2.0 with LLVM Exceptions.
+// See https://github.com/llvm-mos/llvm-mos-sdk/blob/main/LICENSE for license
+// information.
+
+#include <mega65.h>
+
+mega65_lfs_t mega65_k_getlfs(void) {
+  uint8_t a, x, y;
+  asm volatile("jsr __GETLFS" : "=a"(a), "=x"(x), "=y"(y) : : "p");
+  return (mega65_lfs_t){.la = a, .fa = x, .sa = y};
+}

--- a/mos-platform/mega65/mega65_k_lda_far.c
+++ b/mos-platform/mega65/mega65_k_lda_far.c
@@ -1,0 +1,28 @@
+// Copyright 2026 LLVM-MOS Project
+// Licensed under the Apache License, Version 2.0 with LLVM Exceptions.
+// See https://github.com/llvm-mos/llvm-mos-sdk/blob/main/LICENSE for license
+// information.
+
+#include <mega65.h>
+
+/// Read a byte from any MEGA65 bank via KERNAL LDA_FAR ($FF74).
+uint8_t mega65_k_lda_far(uint8_t bank, uint16_t addr, uint8_t y_offset) {
+  uint8_t addr_lo = (uint8_t)addr;
+  uint8_t addr_hi = (uint8_t)(addr >> 8);
+  uint8_t result;
+  // LDA_FAR wants the address in a zero-page pair pointed to by X. $FB/$FC is
+  // free on both sides: the ROM's base-page allocations end at $FA, and the
+  // compiler's zero page ends at $8F. The bank goes in Z, and LDA_FAR hands
+  // Z back as it found it, so it has to be cleared before returning.
+  asm volatile("stx $fb\n"
+               "sty $fc\n"
+               "taz\n"
+               "ldy %[idx]\n"
+               "ldx #$fb\n"
+               "jsr __LDA_FAR\n"
+               "ldz #0\n"
+               : "=a"(result), "+x"(addr_lo), "+y"(addr_hi)
+               : "a"(bank), [idx] "r"(y_offset)
+               : "p");
+  return result;
+}

--- a/mos-platform/mega65/mega65_k_lkupla.c
+++ b/mos-platform/mega65/mega65_k_lkupla.c
@@ -1,0 +1,27 @@
+// Copyright 2026 LLVM-MOS Project
+// Licensed under the Apache License, Version 2.0 with LLVM Exceptions.
+// See https://github.com/llvm-mos/llvm-mos-sdk/blob/main/LICENSE for license
+// information.
+
+#include <mega65.h>
+
+/// Search for a logical file number in use (LKUPLA, $FF5F).
+/// @return 0 if found (writes device and SA to output params), 1 if not found.
+uint8_t mega65_k_lkupla(uint8_t la, uint8_t *fa, uint8_t *sa) {
+  uint8_t x, y, missing;
+  // The answer is in the carry, which has to be consumed here: "=c" outputs
+  // miscompile (see mega65_k_load.c).
+  asm volatile("jsr __LKUPLA\n"
+               "lda #0\n"
+               "bcc 1f\n"
+               "lda #1\n"
+               "1:\n"
+               : "=a"(missing), "=x"(x), "=y"(y)
+               : "a"(la)
+               : "p");
+  if (missing)
+    return 1;
+  *fa = x;
+  *sa = y;
+  return 0;
+}

--- a/mos-platform/mega65/mega65_k_lkupsa.c
+++ b/mos-platform/mega65/mega65_k_lkupsa.c
@@ -1,0 +1,31 @@
+// Copyright 2026 LLVM-MOS Project
+// Licensed under the Apache License, Version 2.0 with LLVM Exceptions.
+// See https://github.com/llvm-mos/llvm-mos-sdk/blob/main/LICENSE for license
+// information.
+
+#include <mega65.h>
+
+/// Search for a secondary address in use (LKUPSA, $FF62).
+/// @return 0 if found (writes LA and device to output params), 1 if not found.
+uint8_t mega65_k_lkupsa(uint8_t sa, uint8_t *la, uint8_t *fa) {
+  uint8_t a, x, missing;
+  // A holds the logical file number on return, so the carry is parked in an
+  // imaginary register rather than in A. "=c" outputs miscompile (see
+  // mega65_k_load.c).
+  asm volatile("jsr __LKUPSA\n"
+               "pha\n"
+               "lda #0\n"
+               "bcc 1f\n"
+               "lda #1\n"
+               "1:\n"
+               "sta %[missing]\n"
+               "pla\n"
+               : "=a"(a), "=x"(x), [missing] "=&r"(missing), "+y"(sa)
+               :
+               : "p");
+  if (missing)
+    return 1;
+  *la = a;
+  *fa = x;
+  return 0;
+}

--- a/mos-platform/mega65/mega65_k_load.c
+++ b/mos-platform/mega65/mega65_k_load.c
@@ -1,0 +1,35 @@
+// Copyright 2026 LLVM-MOS Project
+// Licensed under the Apache License, Version 2.0 with LLVM Exceptions.
+// See https://github.com/llvm-mos/llvm-mos-sdk/blob/main/LICENSE for license
+// information.
+
+#include <mega65.h>
+
+/// Load or verify a file (LOAD, $FFD5). Supports MEGA65 raw mode (flag bit 6).
+/// flag: 0x00=load, 0x01=verify, 0x40=raw load, 0x41=raw verify.
+/// Raw mode treats the first two bytes as data instead of a PRG header.
+/// Requires SETBNK, SETLFS, SETNAM called first.
+/// @return 0 on success (writes *end_addr), or KERNAL error code (1-9).
+uint8_t mega65_k_load(uint8_t flag, void *load_addr, void **end_addr) {
+  uint8_t addr_lo = (uint8_t)(uint16_t)load_addr;
+  uint8_t addr_hi = (uint8_t)((uint16_t)load_addr >> 8);
+  uint8_t end_lo, end_hi, err;
+
+  // The carry must be tested inside the block. An "=c" output miscompiles:
+  // on clang 22 it aborts the LTO link outright, and on later versions it
+  // trips a register-scavenger assertion once the program is big enough.
+  // LOAD leaves Z at 0 on the slow and burst paths but at 3 on the FastLoad
+  // path, so it always has to be cleared.
+  asm volatile("jsr __LOAD\n"
+               "bcs 1f\n"
+               "lda #0\n"
+               "1:\n"
+               "ldz #0"
+               : "=a"(err), "=x"(end_lo), "=y"(end_hi)
+               : "a"(flag), "x"(addr_lo), "y"(addr_hi)
+               : "p");
+  if (!err) {
+    *end_addr = (void *)((uint16_t)end_hi << 8 | end_lo);
+  }
+  return err;
+}

--- a/mos-platform/mega65/mega65_k_plot.c
+++ b/mos-platform/mega65/mega65_k_plot.c
@@ -1,0 +1,29 @@
+// Copyright 2026 LLVM-MOS Project
+// Licensed under the Apache License, Version 2.0 with LLVM Exceptions.
+// See https://github.com/llvm-mos/llvm-mos-sdk/blob/main/LICENSE for license
+// information.
+
+#include <mega65.h>
+
+/// Get cursor position relative to the active window (PLOT, $FFF0).
+mega65_plot_t mega65_k_plot_get(void) {
+  uint8_t l, c;
+  asm volatile("sec\n"
+               "jsr __PLOT"
+               : "=x"(l), "=y"(c)
+               :
+               : "a", "p");
+  return (mega65_plot_t){.line = l, .col = c};
+}
+
+/// Set cursor position relative to the active window (PLOT, $FFF0).
+void mega65_k_plot_set(uint8_t line, uint8_t col) {
+  // The set path falls through into the read path, which recomputes X and Y
+  // from the cursor variables; X comes back one short of the line it was
+  // given, so neither register survives the call intact.
+  asm volatile("clc\n"
+               "jsr __PLOT"
+               : "+x"(line), "+y"(col)
+               :
+               : "a", "p");
+}

--- a/mos-platform/mega65/mega65_k_rdtim.c
+++ b/mos-platform/mega65/mega65_k_rdtim.c
@@ -1,0 +1,26 @@
+// Copyright 2026 LLVM-MOS Project
+// Licensed under the Apache License, Version 2.0 with LLVM Exceptions.
+// See https://github.com/llvm-mos/llvm-mos-sdk/blob/main/LICENSE for license
+// information.
+
+#include <mega65.h>
+
+/// Read the CIA1 time-of-day clock (RDTIM, $FFDE).
+/// All values are in BCD format (e.g. 0x59 = 59 decimal).
+mega65_tod_t mega65_k_rdtim(void) {
+  mega65_tod_t tod;
+  // Tenths are returned in Z, which has to be emptied and cleared before
+  // returning to compiled code. Reading the tenths register also releases the
+  // TOD latch, so it must be read last.
+  asm volatile("jsr __RDTIM\n"
+               "pha\n"
+               "tza\n"
+               "ldz #0\n"
+               "sta %[tenths]\n"
+               "pla\n"
+               : "=a"(tod.seconds), "=x"(tod.minutes),
+                 "=y"(tod.hours), [tenths] "=&r"(tod.tenths)
+               :
+               : "p");
+  return tod;
+}

--- a/mos-platform/mega65/mega65_k_savefl.c
+++ b/mos-platform/mega65/mega65_k_savefl.c
@@ -1,0 +1,42 @@
+// Copyright 2026 LLVM-MOS Project
+// Licensed under the Apache License, Version 2.0 with LLVM Exceptions.
+// See https://github.com/llvm-mos/llvm-mos-sdk/blob/main/LICENSE for license
+// information.
+
+#include <mega65.h>
+
+#include <stdbool.h>
+
+/// Save memory to a file with optional raw mode (SAVEFL, $FF3B).
+/// In raw mode, the two-byte PRG address header is omitted.
+/// The memory region must fit within a single bank.
+/// Requires SETBNK, SETLFS, SETNAM called first.
+/// @return 0 on success, or KERNAL error code (1-9).
+uint8_t mega65_k_savefl(const void *start_addr, const void *end_addr_plus1,
+                        bool raw) {
+  uint8_t end_lo = (uint8_t)(uint16_t)end_addr_plus1;
+  uint8_t end_hi = (uint8_t)((uint16_t)end_addr_plus1 >> 8);
+  uint8_t flags = raw ? 0x40 : 0x00;
+  uint8_t err;
+  // SAVEFL reads the start address through a zero-page pointer, so it must
+  // live in one: an imaginary register pair is the cheapest such home, and
+  // "lda #%[zp]" assembles to its zero-page address.
+  uint16_t zp_ptr = (uint16_t)start_addr;
+
+  // Flags are passed in Z, so Z has to be restored to 0 before returning to
+  // compiled code. The save itself runs through X and Y, and the carry is
+  // carry consumed inside the block; see mega65_k_load.c for why.
+  asm volatile("lda %[flags]\n"
+               "taz\n"
+               "lda #%[zp]\n"
+               "jsr __SAVEFL\n"
+               "ldz #0\n"
+               "bcs 1f\n"
+               "lda #0\n"
+               "1:\n"
+               : "=&a"(err), [zp] "+r"(zp_ptr), "+x"(end_lo), "+y"(end_hi)
+               : [flags] "r"(flags)
+               : "p");
+
+  return err;
+}

--- a/mos-platform/mega65/mega65_k_scrorg.c
+++ b/mos-platform/mega65/mega65_k_scrorg.c
@@ -1,0 +1,31 @@
+// Copyright 2026 LLVM-MOS Project
+// Licensed under the Apache License, Version 2.0 with LLVM Exceptions.
+// See https://github.com/llvm-mos/llvm-mos-sdk/blob/main/LICENSE for license
+// information.
+
+#include <mega65.h>
+
+/// Get screen window size and properties (SCRORG, $FFED).
+mega65_screen_info_t mega65_k_scrorg(void) {
+  mega65_screen_info_t info;
+  // SCRORG answers in all four registers plus the carry: A/Z are the window
+  // address, X/Y its size, C the 40-column flag. Z has to be emptied and
+  // cleared before returning to compiled code, and the carry consumed here
+  // because "=c" outputs miscompile (see mega65_k_load.c).
+  asm volatile("jsr __SCREEN\n"
+               "pha\n"
+               "tza\n"
+               "ldz #0\n"
+               "sta %[hi]\n"
+               "lda #0\n"
+               "bcc 1f\n"
+               "lda #1\n"
+               "1:\n"
+               "sta %[wide]\n"
+               "pla\n"
+               : "=a"(info.addr_lo), "=x"(info.max_col), "=y"(info.max_row),
+                 [hi] "=&r"(info.addr_hi), [wide] "=&r"(info.is_40col)
+               :
+               : "p");
+  return info;
+}

--- a/mos-platform/mega65/mega65_k_setbnk.c
+++ b/mos-platform/mega65/mega65_k_setbnk.c
@@ -1,0 +1,30 @@
+// Copyright 2026 LLVM-MOS Project
+// Licensed under the Apache License, Version 2.0 with LLVM Exceptions.
+// See https://github.com/llvm-mos/llvm-mos-sdk/blob/main/LICENSE for license
+// information.
+
+#include <mega65.h>
+
+/// Set bank for LOAD/SAVE/VERIFY/OPEN data and filename addresses (SETBNK,
+/// $FF6B).
+void mega65_k_setbnk(uint8_t mem_bank, uint8_t fn_bank) {
+  // SETBNK ends with "txa", so A does not survive the call.
+  asm volatile("jsr __SETBNK" : "+a"(mem_bank) : "x"(fn_bank) : "y", "p");
+}
+
+/// Set 28-bit bank for LOAD/SAVE/VERIFY/OPEN data and filename addresses
+/// (SETBNK, $FF6B).
+void mega65_k_setbnk_28(uint8_t mem_mb, uint8_t mem_hi, uint8_t fn_mb,
+                        uint8_t fn_hi) {
+  // Bit 7 signals 28-bit mode to the KERNAL
+  uint8_t a = 0x80 | mem_mb;
+  uint8_t x = 0x80 | fn_mb;
+  // The filename bank byte is passed in Z, so Z has to be restored to 0
+  // before returning to compiled code. A does not survive ("txa").
+  asm volatile("ldz %[fnhi]\n"
+               "jsr __SETBNK\n"
+               "ldz #0\n"
+               : "+a"(a)
+               : "x"(x), "y"(mem_hi), [fnhi] "r"(fn_hi)
+               : "p");
+}

--- a/mos-platform/mega65/mega65_k_setmsg.c
+++ b/mos-platform/mega65/mega65_k_setmsg.c
@@ -1,0 +1,12 @@
+// Copyright 2026 LLVM-MOS Project
+// Licensed under the Apache License, Version 2.0 with LLVM Exceptions.
+// See https://github.com/llvm-mos/llvm-mos-sdk/blob/main/LICENSE for license
+// information.
+
+#include <mega65.h>
+
+/// Enable or disable KERNAL messages (SETMSG, $FF90).
+/// Bit 7 = control messages, bit 6 = error messages.
+void mega65_k_setmsg(uint8_t mode) {
+  asm volatile("jsr __SETMSG" : : "a"(mode) : "x", "y", "p");
+}

--- a/mos-platform/mega65/mega65_k_settim.c
+++ b/mos-platform/mega65/mega65_k_settim.c
@@ -1,0 +1,20 @@
+// Copyright 2026 LLVM-MOS Project
+// Licensed under the Apache License, Version 2.0 with LLVM Exceptions.
+// See https://github.com/llvm-mos/llvm-mos-sdk/blob/main/LICENSE for license
+// information.
+
+#include <mega65.h>
+
+/// Set the CIA1 time-of-day clock (SETTIM, $FFDB).
+/// All values are in BCD format (e.g. 0x59 = 59 decimal).
+void mega65_k_settim(uint8_t hours, uint8_t minutes, uint8_t seconds,
+                     uint8_t tenths) {
+  // Tenths are passed in Z, so Z has to be restored to 0 before returning to
+  // compiled code. SETTIM rewrites Y with the PM-adjusted hour.
+  asm volatile("ldz %[tenths]\n"
+               "jsr __SETTIM\n"
+               "ldz #0\n"
+               : "+y"(hours)
+               : "a"(seconds), "x"(minutes), [tenths] "r"(tenths)
+               : "p");
+}

--- a/mos-platform/mega65/mega65_k_sta_far.c
+++ b/mos-platform/mega65/mega65_k_sta_far.c
@@ -1,0 +1,25 @@
+// Copyright 2026 LLVM-MOS Project
+// Licensed under the Apache License, Version 2.0 with LLVM Exceptions.
+// See https://github.com/llvm-mos/llvm-mos-sdk/blob/main/LICENSE for license
+// information.
+
+#include <mega65.h>
+
+/// Store a byte to any MEGA65 bank via KERNAL STA_FAR ($FF77).
+void mega65_k_sta_far(uint8_t bank, uint16_t addr, uint8_t y_offset,
+                      uint8_t value) {
+  uint8_t addr_lo = (uint8_t)addr;
+  uint8_t addr_hi = (uint8_t)(addr >> 8);
+  // See mega65_k_lda_far.c for the $FB/$FC scratch pair and the Z handling.
+  asm volatile("stx $fb\n"
+               "sty $fc\n"
+               "taz\n"
+               "lda %[val]\n"
+               "ldy %[idx]\n"
+               "ldx #$fb\n"
+               "jsr __STA_FAR\n"
+               "ldz #0\n"
+               : "+a"(bank), "+x"(addr_lo), "+y"(addr_hi)
+               : [idx] "r"(y_offset), [val] "r"(value)
+               : "p");
+}

--- a/mos-platform/mega65/mega65_k_swapper.c
+++ b/mos-platform/mega65/mega65_k_swapper.c
@@ -1,0 +1,16 @@
+// Copyright 2026 LLVM-MOS Project
+// Licensed under the Apache License, Version 2.0 with LLVM Exceptions.
+// See https://github.com/llvm-mos/llvm-mos-sdk/blob/main/LICENSE for license
+// information.
+
+#include <mega65.h>
+
+/// Toggle between 40x25 and 80x25 text modes (SWAPPER, $FF65).
+void mega65_k_swapper(void) {
+  // set_screen_mode leaves Z holding the x-scroll value.
+  asm volatile("jsr __SWAPPER\n"
+               "ldz #0"
+               :
+               :
+               : "a", "x", "y", "p");
+}

--- a/mos-platform/mega65/mega65_k_sysflags.c
+++ b/mos-platform/mega65/mega65_k_sysflags.c
@@ -1,0 +1,24 @@
+// Copyright 2026 LLVM-MOS Project
+// Licensed under the Apache License, Version 2.0 with LLVM Exceptions.
+// See https://github.com/llvm-mos/llvm-mos-sdk/blob/main/LICENSE for license
+// information.
+
+#include <mega65.h>
+
+uint8_t mega65_k_sysflags_get(void) {
+  uint8_t locks;
+  asm volatile("sec\n"
+               "jsr __SYSFLAGS"
+               : "=a"(locks)
+               :
+               : "x", "y", "p");
+  return locks;
+}
+
+void mega65_k_sysflags_set(uint8_t locks) {
+  asm volatile("clc\n"
+               "jsr __SYSFLAGS"
+               :
+               : "a"(locks)
+               : "x", "y", "p");
+}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,3 +1,7 @@
+# Targets whose platform sources change often enough that the inner build
+# cannot be trusted to notice.
+set(TEST_TARGETS_NEEDING_PLATFORM_SYNC mega65)
+
 function(add_test_target target)
   get_filename_component(llvm_mos ${LLVM_MOS_C_COMPILER} DIRECTORY)
   ExternalProject_Get_Property(mos-platform INSTALL_DIR)
@@ -21,11 +25,25 @@ function(add_test_target target)
       -DCMAKE_C_FLAGS=${config_flag}
       -DCMAKE_CXX_FLAGS=${config_flag}
       -DCMAKE_TOOLCHAIN_FILE=${CMAKE_SOURCE_DIR}/cmake/llvm-mos-toolchain.cmake
+      ${ARGN}
     INSTALL_COMMAND ""
     BUILD_ALWAYS On
     TEST_AFTER_INSTALL On
     EXCLUDE_FROM_ALL YES
     DEPENDS mos-platform)
+  # ExternalProject boundaries hide platform source changes from the inner
+  # build, so a target whose platform is being worked on has to be cleaned or
+  # it runs against stale objects. Opt-in: cleaning every target on every run
+  # rebuilds all of them from scratch.
+  if(target IN_LIST TEST_TARGETS_NEEDING_PLATFORM_SYNC)
+    ExternalProject_Add_Step(test-${target} platform-sync
+      COMMAND ${CMAKE_COMMAND} --build <BINARY_DIR> --target clean
+      COMMENT "Cleaning test-${target} to pick up platform changes"
+      DEPENDEES configure
+      DEPENDERS build
+      ALWAYS 1)
+  endif()
+
   add_dependencies(test test-${target})
   set_property(TARGET test-${target} PROPERTY
     ADDITIONAL_CLEAN_FILES ${CMAKE_BINARY_DIR}/test/${target})
@@ -43,3 +61,9 @@ add_test_target(atari2600-4k)
 add_test_target(atari2600-3e)
 add_test_target(atari8-dos)
 add_test_target(atari8-cart-std)
+if(XMEGA65_COMMAND)
+  add_test_target(mega65
+    -DXMEGA65_COMMAND=${XMEGA65_COMMAND}
+    -DPYTHON3_COMMAND=${PYTHON3_COMMAND}
+    -DD81_SCRIPT=${CMAKE_SOURCE_DIR}/mos-platform/mega65/d81.py)
+endif()

--- a/test/mega65-common/xemu-test.h
+++ b/test/mega65-common/xemu-test.h
@@ -1,0 +1,46 @@
+// Shared xemu test utilities for MEGA65 tests.
+// Uses the xemu $D6CF control register to signal test exit codes.
+
+#ifndef XEMU_TEST_H
+#define XEMU_TEST_H
+
+#include <mega65.h>
+#include <stdint.h>
+
+#define XEMU_CONTROL (*(volatile uint8_t *)0xd6cf)
+#define XEMU_QUIT 0x42
+
+static __attribute__((noinline, noreturn)) void xemu_exit(uint8_t code) {
+  // MAP outranks $01/$D030 banking, so a MAP block covering $C000-$DFFF
+  // hides I/O, and $D6CF with it. Clear MAP so $D000-$DFFF falls through
+  // to I/O routing whatever the caller left mapped.
+  asm volatile("lda #$00\n\t"
+               "tax\n\t"
+               "tay\n\t"
+               "taz\n\t"
+               "map\n\t"
+               "eom\n\t"
+               "sei" ::
+                   : "a", "x", "y", "p");
+  // One pair suffices whatever came before: each write stores its byte as the
+  // new key, so the first sets up the second.
+  VICIV.key = VIC4_KEY_VICIV_A;
+  VICIV.key = VIC4_KEY_VICIV_B;
+  XEMU_CONTROL = code;
+  XEMU_CONTROL = XEMU_QUIT;
+  // Wait for the emulator to go. An empty loop would be undefined behaviour
+  // and may be deleted, letting control run off the end of this function.
+  for (;;)
+    asm volatile("");
+}
+
+// Assert condition; on failure exits with source line number as exit code.
+// Exit codes are one byte, so a line past 255 is clamped rather than wrapped:
+// wrapping line 256 would report 0, which is the code for success.
+#define xemu_assert(cond)                                                      \
+  do {                                                                         \
+    if (!(cond))                                                               \
+      xemu_exit(__LINE__ > 255 ? 255 : (uint8_t)__LINE__);                     \
+  } while (0)
+
+#endif // XEMU_TEST_H

--- a/test/mega65/CMakeLists.txt
+++ b/test/mega65/CMakeLists.txt
@@ -1,0 +1,136 @@
+cmake_minimum_required(VERSION 3.18)
+
+project(test-mega65 LANGUAGES C)
+
+include(../test.cmake)
+
+# MEGA65 test via xmega65 emulator. The test binary signals pass/fail
+# through the xemu control register at $D6CF.
+function(add_mega65_test name)
+  set(source_dir ".")
+  if(ARGC GREATER 1)
+    set(source_dir ${ARGV1})
+  endif()
+  if(NOT XMEGA65_COMMAND)
+    return()
+  endif()
+  add_executable(${name}.prg ${source_dir}/${name}.c)
+  add_test(NAME test-${name} COMMAND
+    ${XMEGA65_COMMAND} -headless -sleepless -testing
+    -prg $<TARGET_FILE:${name}.prg> -prgmode 65)
+  set_tests_properties(test-${name} PROPERTIES TIMEOUT 10)
+endfunction()
+
+# MEGA65 HDOS test: virtualizes SD card file access via Hyppo hypervisor.
+# Creates an hdos directory next to the test binary; the caller populates
+# it with test data files (see add_custom_command examples).
+function(add_mega65_hdos_test name)
+  set(source_dir ".")
+  if(ARGC GREATER 1)
+    set(source_dir ${ARGV1})
+  endif()
+  if(NOT XMEGA65_COMMAND)
+    return()
+  endif()
+  add_executable(${name}.prg ${source_dir}/${name}.c)
+
+  add_custom_command(TARGET ${name}.prg POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E make_directory
+      $<TARGET_FILE_DIR:${name}.prg>/${name}_hdos
+    COMMENT "Creating HDOS directory for ${name}")
+
+  add_test(NAME test-${name} COMMAND
+    ${XMEGA65_COMMAND} -headless -sleepless -testing -fastboot
+    -hdosvirt -hdosdir $<TARGET_FILE_DIR:${name}.prg>/${name}_hdos
+    -prg $<TARGET_FILE:${name}.prg> -prgmode 65)
+  set_tests_properties(test-${name} PROPERTIES TIMEOUT 10)
+endfunction()
+
+# MEGA65 disk test: creates a D81 with test data, injects the PRG via -prg,
+# and mounts the D81 on device 8. Signals through $D6CF like the others.
+function(add_mega65_disk_test name)
+  set(source_dir ".")
+  set(extra_files ${ARGN})
+  if(ARGC GREATER 1)
+    set(source_dir ${ARGV1})
+    list(REMOVE_AT extra_files 0)
+  endif()
+  if(NOT XMEGA65_COMMAND)
+    return()
+  endif()
+  if(NOT PYTHON3_COMMAND)
+    return()
+  endif()
+  add_executable(${name}.prg ${source_dir}/${name}.c)
+
+  # extra arguments are PATH=CBMNAME specs to put on the image
+  add_custom_command(TARGET ${name}.prg POST_BUILD
+    COMMAND ${PYTHON3_COMMAND} ${D81_SCRIPT}
+      $<TARGET_FILE_DIR:${name}.prg>/${name}.d81 -n test -i 01 ${extra_files}
+    COMMENT "Creating D81 for ${name}")
+
+  add_test(NAME test-${name} COMMAND
+    ${XMEGA65_COMMAND} -headless -sleepless -testing
+    -prg $<TARGET_FILE:${name}.prg> -prgmode 65
+    -8 $<TARGET_FILE_DIR:${name}.prg>/${name}.d81)
+  set_tests_properties(test-${name} PROPERTIES TIMEOUT 10)
+endfunction()
+
+# Payload shared by the hyppo and hyppo-fileio fixtures: DE AD BE EF CA FE BA BE
+string(ASCII 222 173 190 239 202 254 186 190 _test_payload)
+file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/TEST.BIN" "${_test_payload}")
+
+# d81.py checks its own format code; no emulator needed, only python3.
+if(PYTHON3_COMMAND)
+  add_test(NAME test-d81 COMMAND ${PYTHON3_COMMAND} ${D81_SCRIPT} --selftest)
+  set_tests_properties(test-d81 PROPERTIES TIMEOUT 10)
+endif()
+
+add_mega65_test(kernal)
+add_mega65_test(kernal-far)
+
+# Load address ($7101 LE) plus 8 bytes; no $00, which string(ASCII) cannot hold.
+string(ASCII 1 113 222 173 190 239 202 254 186 190 _disk_test_data)
+file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/TEST.PRG" "${_disk_test_data}")
+
+add_mega65_disk_test(disk "." "${CMAKE_CURRENT_BINARY_DIR}/TEST.PRG=test")
+
+add_mega65_hdos_test(hyppo)
+if(TARGET hyppo.prg)
+  add_custom_command(TARGET hyppo.prg POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy
+      "${CMAKE_CURRENT_BINARY_DIR}/TEST.BIN"
+      "$<TARGET_FILE_DIR:hyppo.prg>/hyppo_hdos/TEST.BIN"
+    COMMENT "Copying TEST.BIN to hyppo hdos directory")
+endif()
+
+add_mega65_test(hyppo-status)
+
+add_mega65_hdos_test(hyppo-dir)
+if(TARGET hyppo-dir.prg)
+  # Create two small text files for findfile/readdir tests
+  file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/FILE1.TXT" "hello")
+  file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/FILE2.TXT" "world")
+  # A subdirectory as well, so chdir has somewhere to go.
+  file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/INNER.TXT" "inner")
+  add_custom_command(TARGET hyppo-dir.prg POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy
+      "${CMAKE_CURRENT_BINARY_DIR}/FILE1.TXT"
+      "$<TARGET_FILE_DIR:hyppo-dir.prg>/hyppo-dir_hdos/FILE1.TXT"
+    COMMAND ${CMAKE_COMMAND} -E copy
+      "${CMAKE_CURRENT_BINARY_DIR}/FILE2.TXT"
+      "$<TARGET_FILE_DIR:hyppo-dir.prg>/hyppo-dir_hdos/FILE2.TXT"
+    COMMAND ${CMAKE_COMMAND} -E copy
+      "${CMAKE_CURRENT_BINARY_DIR}/INNER.TXT"
+      "$<TARGET_FILE_DIR:hyppo-dir.prg>/hyppo-dir_hdos/SUBDIR/INNER.TXT"
+    COMMENT "Copying test files to hyppo-dir hdos directory")
+endif()
+
+add_mega65_hdos_test(hyppo-fileio)
+if(TARGET hyppo-fileio.prg)
+  add_custom_command(TARGET hyppo-fileio.prg POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy
+      "${CMAKE_CURRENT_BINARY_DIR}/TEST.BIN"
+      "$<TARGET_FILE_DIR:hyppo-fileio.prg>/hyppo-fileio_hdos/TEST.BIN"
+    COMMENT "Copying TEST.BIN to hyppo-fileio hdos directory")
+endif()

--- a/test/mega65/disk.c
+++ b/test/mega65/disk.c
@@ -1,0 +1,459 @@
+// MEGA65 D81 disk I/O test — injected via -prg with D81 on device 8.
+// Reads/writes test files via KERNAL I/O and verifies.
+// The test data file is written to the D81 at build time by d81.py.
+//
+
+#include <cbm.h>
+#include <mega65.h>
+#include <stdint.h>
+
+#include "../mega65-common/xemu-test.h"
+
+// The KERNAL's disk path leaves a MAP block selected, which xemu mis-routes
+// $D6CF writes under; xemu_exit clears the MAP before signalling.
+#define test_fail(code) xemu_exit(code)
+
+#define DEVICE 8             // disk drive device number
+#define LOAD_RAW 0x40        // LOAD/SAVEFL flag: raw mode (no PRG header)
+#define READST_ERR_MASK 0xBF // READST error bits excluding EOI (bit 6)
+#define SERIAL_SA_FLAG 0x60  // KERNAL ORs SA with this in file table
+
+// Exit codes — enum values double as documentation.
+// Base+i codes indicate data mismatch at byte offset i.
+enum {
+  EXIT_OK = 0,
+
+  EXIT_SEQ_OPEN = 1,
+  EXIT_SEQ_CHKIN = 2,
+  EXIT_SEQ_READST = 4,
+  EXIT_SEQ_DATA = 30,
+
+  EXIT_LOAD_SA0 = 5,
+  EXIT_LOAD_SA0_END = 6,
+  EXIT_LOAD_SA0_DATA = 50,
+
+  EXIT_LOAD_SA1 = 7,
+  EXIT_LOAD_SA1_END = 8,
+  EXIT_LOAD_SA1_DATA = 70,
+
+  EXIT_LOAD_RAW = 9,
+  EXIT_LOAD_RAW_END = 10,
+  EXIT_LOAD_RAW_DATA = 100,
+
+  EXIT_WRITE_OPEN = 11,
+  EXIT_WRITE_CHKOUT = 12,
+  EXIT_READBACK_OPEN = 13,
+  EXIT_READBACK_CHKIN = 14,
+  EXIT_READBACK_READST = 15,
+  EXIT_READBACK_DATA = 120,
+
+  EXIT_FTABLE_OPEN = 16,
+  EXIT_LKUPLA_NOTFOUND = 17,
+  EXIT_LKUPLA_DEVICE = 18,
+  EXIT_LKUPLA_SA = 19,
+  EXIT_LKUPSA_NOTFOUND = 20,
+  EXIT_LKUPSA_LFN = 21,
+  EXIT_LKUPSA_DEVICE = 22,
+  EXIT_CLOSEALL = 23,
+
+  EXIT_GETLFS_LA = 24,
+  EXIT_GETLFS_FA = 25,
+  EXIT_GETLFS_SA = 26,
+
+  EXIT_GETIO_DEFAULT_IN = 27,
+  EXIT_GETIO_DEFAULT_OUT = 28,
+  EXIT_GETIO_OPEN = 29,
+  EXIT_GETIO_CHKIN = 40,
+  EXIT_GETIO_IN = 41,
+  EXIT_GETIO_OUT = 42,
+
+  EXIT_SAVEFL = 43,
+  EXIT_SAVEFL_LOADBACK = 44,
+  EXIT_SAVEFL_END = 45,
+  EXIT_SAVEFL_DATA = 130,
+
+  EXIT_SAVEFL_RAW = 46,
+  EXIT_SAVEFL_RAW_LOADBACK = 47,
+  EXIT_SAVEFL_RAW_END = 48,
+  EXIT_SAVEFL_RAW_DATA = 140,
+
+  EXIT_CBM_LOAD_END = 60,
+  EXIT_CBM_LOAD_DATA = 61,
+
+  EXIT_CBM_SAVE = 150,
+  EXIT_CBM_SAVE_LOADBACK = 151,
+  EXIT_CBM_SAVE_END = 152,
+  EXIT_CBM_SAVE_DATA = 160,
+
+  EXIT_LOAD_MISSING_OK = 170,     // LOAD of an absent file reported success
+  EXIT_CBM_LOAD_MISSING_OK = 171, // ditto through the commodore wrapper
+  EXIT_OPEN_MISSING_CHKIN = 172,
+  EXIT_ARG_CLOSE_ALL = 173,
+  EXIT_ARG_SAVEFL = 174,
+};
+
+// Shared by more than one phase, so file scope rather than block scope.
+static const uint8_t seq_data[] = {0x01, 0x71, // PRG load address $7101
+                                   0xDE, 0xAD, 0xBE, 0xEF,
+                                   0xCA, 0xFE, 0xBA, 0xBE};
+static const uint8_t save_data[] = {0x11, 0x22, 0x33, 0x44};
+
+static volatile uint8_t arg_in;
+static volatile uint8_t arg_out;
+
+static const uint8_t test_data[] = {0xDE, 0xAD, 0xBE, 0xEF,
+                                    0xCA, 0xFE, 0xBA, 0xBE};
+
+// Verify memory contents match expected data or exit with diagnostic code.
+static void verify(const volatile uint8_t *addr, const uint8_t *expected,
+                   uint8_t len, uint8_t exit_base) {
+  for (uint8_t i = 0; i < len; i++)
+    if (addr[i] != expected[i])
+      test_fail(exit_base + i);
+}
+
+// Each phase is a function of its own on purpose. One main large enough to
+// hold them all is given a dynamic soft-stack frame, and the soft stack grows
+// down from $D000 into the $C000-$CFFF window this test maps the C65 ROM
+// into: a spilled local is written to RAM but read back as ROM. A small phase
+// keeps its state in registers and never spills.
+
+static __attribute__((noinline)) void phase_sequential_read(void) {
+  // --- OPEN/CHKIN/BASIN sequential read ---
+  // PRG header is included as raw data in sequential reads.
+  cbm_k_setlfs(2, DEVICE, 0);
+  cbm_k_setnam("TEST");
+  if (cbm_k_open())
+    test_fail(EXIT_SEQ_OPEN);
+  if (cbm_k_chkin(2))
+    test_fail(EXIT_SEQ_CHKIN);
+
+  for (uint8_t i = 0; i < sizeof(seq_data); i++) {
+    uint8_t ch = cbm_k_basin();
+    uint8_t st = cbm_k_readst();
+    // Allow EOI (bit 6) on the last byte
+    if (i < sizeof(seq_data) - 1 && (st & READST_ERR_MASK))
+      test_fail(EXIT_SEQ_READST);
+    if (ch != seq_data[i])
+      test_fail(EXIT_SEQ_DATA + i);
+  }
+
+  cbm_k_clrch();
+  cbm_k_close(2);
+}
+
+static __attribute__((noinline)) void phase_load_to_address(void) {
+  // --- mega65_k_load to specified address (SA=0) ---
+  static void *end_addr;
+  // KERNAL LOAD with SA=0 strips the 2-byte PRG header and loads data
+  // to the address we specify, not the PRG header address.
+  mega65_k_setbnk(0, 0);
+  cbm_k_setlfs(3, DEVICE, 0);
+  cbm_k_setnam("TEST");
+  if (mega65_k_load(0, (void *)0x4000, &end_addr))
+    test_fail(EXIT_LOAD_SA0);
+  // TEST file has 2-byte PRG header + 8 data bytes; LOAD strips header.
+  if (end_addr != (void *)0x4008)
+    test_fail(EXIT_LOAD_SA0_END);
+  verify((volatile uint8_t *)0x4000, test_data, sizeof(test_data),
+         EXIT_LOAD_SA0_DATA);
+}
+
+static __attribute__((noinline)) void phase_load_to_header_address(void) {
+  // --- mega65_k_load to PRG header address (SA=1) ---
+  static void *end_addr;
+  // SA=1 ignores the caller's address and loads to the address
+  // embedded in the PRG file header ($7101).
+  mega65_k_setbnk(0, 0);
+  cbm_k_setlfs(3, DEVICE, 1);
+  cbm_k_setnam("TEST");
+  if (mega65_k_load(0, (void *)0x4000, &end_addr))
+    test_fail(EXIT_LOAD_SA1);
+  if (end_addr != (void *)0x7109)
+    test_fail(EXIT_LOAD_SA1_END);
+  verify((volatile uint8_t *)0x7101, test_data, sizeof(test_data),
+         EXIT_LOAD_SA1_DATA);
+}
+
+static __attribute__((noinline)) void phase_load_raw(void) {
+  // --- mega65_k_load raw mode (flag=LOAD_RAW) ---
+  static void *end_addr;
+  // Raw mode treats the entire file as data, including the 2-byte PRG header.
+  mega65_k_setbnk(0, 0);
+  cbm_k_setlfs(3, DEVICE, 0);
+  cbm_k_setnam("TEST");
+  if (mega65_k_load(LOAD_RAW, (void *)0x5000, &end_addr))
+    test_fail(EXIT_LOAD_RAW);
+  // Raw: all 10 bytes (2-byte header + 8 data) loaded as-is.
+  if (end_addr != (void *)0x500A)
+    test_fail(EXIT_LOAD_RAW_END);
+  verify((volatile uint8_t *)0x5000, seq_data, sizeof(seq_data),
+         EXIT_LOAD_RAW_DATA);
+}
+
+static __attribute__((noinline)) void phase_write_readback(void) {
+  // --- Write file via BSOUT, read back via BASIN ---
+  // The @: prefix overwrites if the file already exists, making the test
+  // idempotent when the D81 image persists between runs (mounted R/W).
+  static const uint8_t write_data[] = {0x42, 0x43, 0x44, 0x45};
+  cbm_k_setlfs(5, DEVICE, 5);
+  cbm_k_setnam("@:WTEST,S,W");
+  if (cbm_k_open())
+    test_fail(EXIT_WRITE_OPEN);
+  if (cbm_k_chkout(5))
+    test_fail(EXIT_WRITE_CHKOUT);
+  for (uint8_t i = 0; i < sizeof(write_data); i++)
+    cbm_k_bsout(write_data[i]);
+  cbm_k_clrch();
+  cbm_k_close(5);
+
+  // Read back the written file and verify contents.
+  cbm_k_setlfs(6, DEVICE, 6);
+  cbm_k_setnam("WTEST,S,R");
+  if (cbm_k_open())
+    test_fail(EXIT_READBACK_OPEN);
+  if (cbm_k_chkin(6))
+    test_fail(EXIT_READBACK_CHKIN);
+  for (uint8_t i = 0; i < sizeof(write_data); i++) {
+    uint8_t ch = cbm_k_basin();
+    uint8_t st = cbm_k_readst();
+    if (i < sizeof(write_data) - 1 && (st & READST_ERR_MASK))
+      test_fail(EXIT_READBACK_READST);
+    if (ch != write_data[i])
+      test_fail(EXIT_READBACK_DATA + i);
+  }
+  cbm_k_clrch();
+  cbm_k_close(6);
+}
+
+static __attribute__((noinline)) void phase_file_table(void) {
+  // --- File table: lkupla, lkupsa, close_all ---
+  // Open two files to populate the KERNAL file table, then verify
+  // the lookup functions find them with correct parameters.
+  cbm_k_setlfs(7, DEVICE, 7);
+  cbm_k_setnam("TEST");
+  if (cbm_k_open())
+    test_fail(EXIT_FTABLE_OPEN);
+  cbm_k_setlfs(8, DEVICE, 8);
+  cbm_k_setnam("TEST");
+  if (cbm_k_open())
+    test_fail(EXIT_FTABLE_OPEN);
+
+  static uint8_t fa, sa;
+  if (mega65_k_lkupla(7, &fa, &sa))
+    test_fail(EXIT_LKUPLA_NOTFOUND);
+  if (fa != DEVICE)
+    test_fail(EXIT_LKUPLA_DEVICE);
+  // KERNAL stores SA | $60 in the file table (serial bus format).
+  if (sa != (7 | SERIAL_SA_FLAG))
+    test_fail(EXIT_LKUPLA_SA);
+
+  // Round-trip: search by SA from lkupla, verify it finds the same LFN.
+  static uint8_t la;
+  if (mega65_k_lkupsa(sa, &la, &fa))
+    test_fail(EXIT_LKUPSA_NOTFOUND);
+  if (la != 7)
+    test_fail(EXIT_LKUPSA_LFN);
+  if (fa != DEVICE)
+    test_fail(EXIT_LKUPSA_DEVICE);
+
+  // close_all should close both files on device 8.
+  mega65_k_close_all(DEVICE);
+  if (!mega65_k_lkupla(7, &fa, &sa))
+    test_fail(EXIT_CLOSEALL);
+  if (!mega65_k_lkupla(8, &fa, &sa))
+    test_fail(EXIT_CLOSEALL);
+}
+
+static __attribute__((noinline)) void phase_getlfs(void) {
+  // --- getlfs: verify SETLFS state ---
+  // GETLFS returns the global state set by the most recent SETLFS call.
+  cbm_k_setlfs(9, DEVICE, 3);
+  mega65_lfs_t lfs = mega65_k_getlfs();
+  if (lfs.la != 9)
+    test_fail(EXIT_GETLFS_LA);
+  if (lfs.fa != DEVICE)
+    test_fail(EXIT_GETLFS_FA);
+  if (lfs.sa != 3)
+    test_fail(EXIT_GETLFS_SA);
+}
+
+static __attribute__((noinline)) void phase_getio(void) {
+  // --- getio: verify default I/O devices and CHKIN effect ---
+  // After clrch, defaults are keyboard (0) and screen (3).
+  mega65_io_t io = mega65_k_getio();
+  if (io.input_dev != 0)
+    test_fail(EXIT_GETIO_DEFAULT_IN);
+  if (io.output_dev != 3)
+    test_fail(EXIT_GETIO_DEFAULT_OUT);
+  // CHKIN redirects input to the file's device.
+  cbm_k_setlfs(9, DEVICE, 0);
+  cbm_k_setnam("TEST");
+  if (cbm_k_open())
+    test_fail(EXIT_GETIO_OPEN);
+  if (cbm_k_chkin(9))
+    test_fail(EXIT_GETIO_CHKIN);
+  io = mega65_k_getio();
+  if (io.input_dev != DEVICE)
+    test_fail(EXIT_GETIO_IN);
+  if (io.output_dev != 3)
+    test_fail(EXIT_GETIO_OUT);
+  cbm_k_clrch();
+  cbm_k_close(9);
+}
+
+static __attribute__((noinline)) void phase_savefl(void) {
+  // --- SAVEFL normal mode (raw=false): save with PRG header, load back ---
+  static void *end_addr;
+  // Place known data at $6000, save it, then load to $6100 and verify.
+  for (uint8_t i = 0; i < sizeof(save_data); i++)
+    ((volatile uint8_t *)0x6000)[i] = save_data[i];
+  mega65_k_setbnk(0, 0);
+  cbm_k_setlfs(10, DEVICE, 10);
+  cbm_k_setnam("@:STEST,P,W");
+  if (mega65_k_savefl((void *)0x6000, (void *)0x6004, false))
+    test_fail(EXIT_SAVEFL);
+  // Load back with SA=0 (strip PRG header, load to our address).
+  mega65_k_setbnk(0, 0);
+  cbm_k_setlfs(10, DEVICE, 0);
+  cbm_k_setnam("STEST");
+  if (mega65_k_load(0, (void *)0x6100, &end_addr))
+    test_fail(EXIT_SAVEFL_LOADBACK);
+  if (end_addr != (void *)0x6104)
+    test_fail(EXIT_SAVEFL_END);
+  verify((volatile uint8_t *)0x6100, save_data, sizeof(save_data),
+         EXIT_SAVEFL_DATA);
+}
+
+static __attribute__((noinline)) void phase_savefl_raw(void) {
+  // --- SAVEFL raw mode (raw=true): save without PRG header, load back ---
+  static void *end_addr;
+  mega65_k_setbnk(0, 0);
+  cbm_k_setlfs(11, DEVICE, 11);
+  cbm_k_setnam("@:RTEST,P,W");
+  if (mega65_k_savefl((void *)0x6000, (void *)0x6004, true))
+    test_fail(EXIT_SAVEFL_RAW);
+  // Raw load to verify exact bytes without PRG header stripping.
+  mega65_k_setbnk(0, 0);
+  cbm_k_setlfs(11, DEVICE, 0);
+  cbm_k_setnam("RTEST");
+  if (mega65_k_load(LOAD_RAW, (void *)0x6200, &end_addr))
+    test_fail(EXIT_SAVEFL_RAW_LOADBACK);
+  // Raw save omits PRG header, so file is exactly 4 bytes.
+  if (end_addr != (void *)0x6204)
+    test_fail(EXIT_SAVEFL_RAW_END);
+  verify((volatile uint8_t *)0x6200, save_data, sizeof(save_data),
+         EXIT_SAVEFL_RAW_DATA);
+}
+
+static __attribute__((noinline)) void phase_cbm_load(void) {
+  // --- cbm_k_load: verify Commodore LOAD wrapper (SA=0) ---
+  // cbm_k_load has no error return — it returns end address on success
+  // or a tiny pointer (error code) on failure.
+  mega65_k_setbnk(0, 0);
+  cbm_k_setlfs(3, DEVICE, 0);
+  cbm_k_setnam("TEST");
+  void *cbm_end = cbm_k_load(0, (void *)0x4800);
+  if (cbm_end != (void *)0x4808)
+    test_fail(EXIT_CBM_LOAD_END);
+  verify((volatile uint8_t *)0x4800, test_data, sizeof(test_data),
+         EXIT_CBM_LOAD_DATA);
+}
+
+static __attribute__((noinline)) void phase_cbm_save(void) {
+  // --- cbm_k_save: verify standard CBM SAVE wrapper ---
+  static void *end_addr;
+  // Save data at $6300, load back to $6400, verify.
+  static const uint8_t cbm_save_data[] = {0x55, 0xAA, 0x77, 0x88};
+  for (uint8_t i = 0; i < sizeof(cbm_save_data); i++)
+    ((volatile uint8_t *)0x6300)[i] = cbm_save_data[i];
+  mega65_k_setbnk(0, 0);
+  cbm_k_setlfs(12, DEVICE, 12);
+  cbm_k_setnam("@:CSTEST,P,W");
+  if (cbm_k_save((void *)0x6300, (void *)0x6304))
+    test_fail(EXIT_CBM_SAVE);
+  // Load back with SA=0 (strip PRG header, load to our address).
+  mega65_k_setbnk(0, 0);
+  cbm_k_setlfs(12, DEVICE, 0);
+  cbm_k_setnam("CSTEST");
+  if (mega65_k_load(0, (void *)0x6400, &end_addr))
+    test_fail(EXIT_CBM_SAVE_LOADBACK);
+  if (end_addr != (void *)0x6404)
+    test_fail(EXIT_CBM_SAVE_END);
+  verify((volatile uint8_t *)0x6400, cbm_save_data, sizeof(cbm_save_data),
+         EXIT_CBM_SAVE_DATA);
+}
+
+static __attribute__((noinline)) void phase_error_paths(void) {
+  // --- Error paths: the success path is what every other phase covers ---
+  // A name that is not on the image. LOAD must report the failure rather than
+  // hand back an end address.
+  void *end_addr;
+  mega65_k_setbnk(0, 0);
+  cbm_k_setlfs(11, DEVICE, 0);
+  cbm_k_setnam("NOSUCH");
+  if (mega65_k_load(0, (void *)0x4000, &end_addr) == 0)
+    test_fail(EXIT_LOAD_MISSING_OK);
+
+  // cbm_k_load has no error return of its own, so the code comes back as a
+  // pointer. Compare against what mega65_k_load reports for the same request:
+  // a bound like "small integer" passes even when the value is uninitialised.
+  mega65_k_setbnk(0, 0);
+  cbm_k_setlfs(11, DEVICE, 0);
+  cbm_k_setnam("NOSUCH");
+  uint8_t err = mega65_k_load(0, (void *)0x4000, &end_addr);
+  mega65_k_setbnk(0, 0);
+  cbm_k_setlfs(11, DEVICE, 0);
+  cbm_k_setnam("NOSUCH");
+  if ((uint16_t)cbm_k_load(0, (void *)0x4000) != err)
+    test_fail(EXIT_CBM_LOAD_MISSING_OK);
+
+  // Arguments the ROM destroys, for the two wrappers the other phases do not
+  // cover. Volatile keeps the value in a register across the call.
+  arg_in = DEVICE;
+  {
+    uint8_t device = arg_in;
+    mega65_k_close_all(device);
+    arg_out = device;
+  }
+  if (arg_out != DEVICE)
+    test_fail(EXIT_ARG_CLOSE_ALL);
+
+  arg_in = 0x60;
+  {
+    uint8_t end_lo = arg_in;
+    mega65_k_setbnk(0, 0);
+    cbm_k_setlfs(12, DEVICE, 12);
+    cbm_k_setnam("@:ETEST,P,W");
+    (void)mega65_k_savefl((void *)0x6000, (void *)(((uint16_t)end_lo << 8) | 4),
+                          false);
+    arg_out = end_lo;
+  }
+  if (arg_out != 0x60)
+    test_fail(EXIT_ARG_SAVEFL);
+}
+
+int main(void) {
+  // The KERNAL's disk path reaches its DOS interface at $C000-$CFFF, which
+  // startup (unmap-basic.S) leaves unmapped.
+  VICIV.key = VIC4_KEY_VICIV_A;
+  VICIV.key = VIC4_KEY_VICIV_B;
+  VICIV.ctrla = VIC3_PAL_MASK | VIC3_ROMC_MASK | VIC3_CROM9_MASK;
+  CPU_PORT |= CPU_PORT_LORAM | CPU_PORT_HIRAM | CPU_PORT_CHAREN;
+
+  phase_sequential_read();
+  phase_load_to_address();
+  phase_load_to_header_address();
+  phase_load_raw();
+  phase_write_readback();
+  phase_file_table();
+  phase_getlfs();
+  phase_getio();
+  phase_savefl();
+  phase_savefl_raw();
+  phase_cbm_load();
+  phase_cbm_save();
+  phase_error_paths();
+
+  xemu_exit(EXIT_OK);
+}

--- a/test/mega65/hyppo-dir.c
+++ b/test/mega65/hyppo-dir.c
@@ -1,0 +1,90 @@
+// Hyppo directory service test — exercises mega65_h_findfile, mega65_h_setname_page,
+// mega65_h_opendir, mega65_h_readdir, mega65_h_closedir,
+// mega65_h_selectdrive and mega65_h_cdrootdir.
+//
+// Requires xemu with -hdosvirt -hdosdir containing FILE1.TXT and FILE2.TXT.
+//
+// Exit codes (line numbers via xemu_assert):
+//   0 = all tests passed
+//   non-zero = line number of failed assertion
+
+#include <mega65.h>
+#include <stdint.h>
+
+#include "../mega65-common/xemu-test.h"
+
+// readdir needs a page-aligned buffer below $7F00, and the linker is free to
+// place a .bss object above that. $1600-$1EFF is the range the ROM guarantees
+// it never uses, so the address does not depend on how the test links.
+#define DIRENT_BUF 0x1600
+_Static_assert(DIRENT_BUF % 0x100 == 0, "Hyppo addresses the buffer by page");
+_Static_assert(DIRENT_BUF < 0x7F00, "Hyppo's copy region must fit below $7F00");
+static mega65_h_dirent *const dirent_buf = (mega65_h_dirent *)DIRENT_BUF;
+
+// A second page from the same ROM-free range, for the setname_page tests.
+#define NAME_BUF 0x1700
+_Static_assert(NAME_BUF % 0x100 == 0, "Hyppo addresses the buffer by page");
+_Static_assert(NAME_BUF < 0x7F00, "Hyppo's copy region must fit below $7F00");
+
+int main(void) {
+  // --- Test 1: findfile succeeds for existing file ---
+  xemu_assert(mega65_h_setname("FILE1.TXT") == 0);
+  xemu_assert(mega65_h_findfile() == 0);
+
+  // --- Test 2: findfile fails for non-existent file ---
+  xemu_assert(mega65_h_setname("NOFILE.BIN") == 0);
+  xemu_assert(mega65_h_findfile() != 0);
+
+  // --- Test 3: opendir + readdir + closedir ---
+  uint8_t fd;
+  xemu_assert(mega65_h_opendir(&fd) == 0);
+
+  uint8_t count = 0;
+  while (mega65_h_readdir(fd, dirent_buf) == 0)
+    count++;
+
+  // HDOS dir should contain at least FILE1.TXT and FILE2.TXT
+  xemu_assert(count >= 2);
+
+  mega65_h_closedir(fd);
+
+  // --- Test 4: drive selection and root navigation ---
+  xemu_assert(mega65_h_selectdrive(mega65_h_getcurrentdrive()) == 0);
+  xemu_assert(mega65_h_cdrootdir(mega65_h_getcurrentdrive()) == 0);
+
+  // --- Test 5: chdir into a subdirectory, then back to the root ---
+  xemu_assert(mega65_h_setname("SUBDIR") == 0);
+  xemu_assert(mega65_h_findfile() == 0);
+  xemu_assert(mega65_h_chdir() == 0);
+  xemu_assert(mega65_h_setname("INNER.TXT") == 0);
+  xemu_assert(mega65_h_findfile() == 0);
+  xemu_assert(mega65_h_cdrootdir(mega65_h_getcurrentdrive()) == 0);
+
+  // --- Test 6: setname_page names a buffer the caller staged itself ---
+  // The page form is the one a program needs when it owns the page: two names
+  // alive at once cannot share the single staging buffer setname() writes.
+  static const char wanted[] = "FILE2.TXT";
+  volatile char *name = (volatile char *)NAME_BUF;
+  for (uint8_t i = 0; i < sizeof(wanted); ++i)
+    name[i] = wanted[i];
+  xemu_assert(mega65_h_setname_page(NAME_BUF >> 8) == 0);
+  xemu_assert(mega65_h_findfile() == 0);
+
+  // --- Test 7: a page hyppo refuses to copy from ---
+  xemu_assert(mega65_h_setname_page(0x7F) == MEGA65_H_ERR_INVALID_ADDRESS);
+
+  // Ten wrappers go untested here, all for want of a real SD card image.
+  //
+  // findfirst ($30), findnext ($32), rmfile ($26), writefile ($1C), mkfile
+  // ($1E), d81write_en ($44): xemu's -hdosvirt does not stand in for these,
+  // so they reach real Hyppo, find no card, and fail.
+  //
+  // locate_freezeslot ($10), unfreeze_from_slot ($12),
+  // read_freeze_region_list ($14), get_slot_count ($16): these need a system
+  // partition. Unfreeze could not report back even with one, since it does
+  // not return.
+  //
+  // Testing any of them needs an -sdimg run.
+
+  xemu_exit(0);
+}

--- a/test/mega65/hyppo-fileio.c
+++ b/test/mega65/hyppo-fileio.c
@@ -1,0 +1,55 @@
+// Hyppo file I/O test — exercises mega65_h_openfile, mega65_h_readfile,
+// mega65_h_closefile, mega65_h_closeall via sector-by-sector reading.
+//
+// Requires xemu with -hdosvirt -hdosdir containing TEST.BIN
+// (8 bytes: DE AD BE EF CA FE BA BE).
+//
+// Exit codes (line numbers via xemu_assert):
+//   0 = all tests passed
+//   non-zero = line number of failed assertion
+
+#include <mega65.h>
+#include <stdint.h>
+
+#include "../mega65-common/xemu-test.h"
+
+int main(void) {
+  // --- Test 1: find and open the test file ---
+  xemu_assert(mega65_h_setname("TEST.BIN") == 0);
+  xemu_assert(mega65_h_findfile() == 0);
+
+  uint8_t fd;
+  xemu_assert(mega65_h_openfile(&fd) == 0);
+
+  // --- Test 2: read first (only) sector, verify byte count ---
+  uint16_t count;
+  xemu_assert(mega65_h_readfile(&count) == 0);
+  xemu_assert(count == 8);
+
+  // Note: sector buffer contents at $FFD6E00 are not verified here because
+  // xemu's HDOS virtualization may not populate the physical sector buffer
+  // address for DMA reads. The loadfile test (hyppo.c) already covers
+  // DMA-based data verification via loadfile_attic.
+
+  // --- Test 3: second read should return count == 0 (EOF) ---
+  xemu_assert(mega65_h_readfile(&count) == 0);
+  xemu_assert(count == 0);
+
+  // --- Test 4: closefile should not crash ---
+  mega65_h_closefile(fd);
+
+  // --- Test 5: closeall should not crash ---
+  mega65_h_closeall();
+
+  // --- Test 6: a failed search leaves the previous dirent in place ---
+  // openfile acts on the current dirent, and a findfile that matches nothing
+  // does not clear it, so openfile still succeeds and reopens the earlier
+  // file. Callers have to check findfile themselves.
+  xemu_assert(mega65_h_setname("NOFILE.BIN") == 0);
+  xemu_assert(mega65_h_findfile() != 0);
+  uint8_t stale_fd;
+  xemu_assert(mega65_h_openfile(&stale_fd) == 0);
+  mega65_h_closefile(stale_fd);
+
+  xemu_exit(0);
+}

--- a/test/mega65/hyppo-status.c
+++ b/test/mega65/hyppo-status.c
@@ -1,0 +1,55 @@
+// Hyppo status and drive service test — exercises mega65_h_getversion,
+// mega65_h_geterrorcode, mega65_h_getcurrentdrive, mega65_h_getdefaultdrive.
+//
+// Pure -prg injection test (no filesystem needed).
+//
+// Exit codes (line numbers via xemu_assert):
+//   0 = all tests passed
+//   non-zero = line number of failed assertion
+
+#include <mega65.h>
+#include <stdint.h>
+
+#include "../mega65-common/xemu-test.h"
+
+// get_proc_desc copies a whole page, so it needs one the ROM never touches;
+// $1600-$1EFF is the range the memory map guarantees is free.
+#define PROC_DESC_BUF 0x1800
+_Static_assert(PROC_DESC_BUF % 0x100 == 0,
+               "Hyppo addresses the buffer by page");
+_Static_assert(PROC_DESC_BUF < 0x7F00,
+               "Hyppo's copy region must fit below $7F00");
+
+int main(void) {
+  // --- Test 1: getversion returns nonzero Hyppo version ---
+  mega65_h_version ver = mega65_h_getversion();
+  xemu_assert(ver.hyppo_major != 0);
+
+  // --- Test 2: geterrorcode does not crash ---
+  // After a successful getversion there is no meaningful error code,
+  // but calling it should not hang or crash.
+  (void)mega65_h_geterrorcode();
+
+  // --- Test 3: getcurrentdrive returns 0 (xemu default) ---
+  xemu_assert(mega65_h_getcurrentdrive() == 0);
+
+  // --- Test 4: getdefaultdrive returns 0 (xemu default) ---
+  xemu_assert(mega65_h_getdefaultdrive() == 0);
+
+  // --- Error path: selecting a drive that does not exist fails ---
+  xemu_assert(mega65_h_selectdrive(7) != 0);
+
+  // --- Test 5: get_proc_desc fills a page the caller names ---
+  // Hyppo copies the whole 256-byte descriptor, so a byte the test wrote
+  // beforehand must be gone afterwards -- proof the copy happened rather
+  // than the trap quietly doing nothing.
+  volatile uint8_t *desc = (volatile uint8_t *)PROC_DESC_BUF;
+  desc[0] = 0x5A;
+  xemu_assert(mega65_h_get_proc_desc(PROC_DESC_BUF >> 8) == 0);
+  xemu_assert(desc[0] != 0x5A);
+
+  // --- Error path: a page hyppo refuses to copy into ---
+  xemu_assert(mega65_h_get_proc_desc(0x7F) == MEGA65_H_ERR_INVALID_ADDRESS);
+
+  xemu_exit(0);
+}

--- a/test/mega65/hyppo.c
+++ b/test/mega65/hyppo.c
@@ -1,0 +1,84 @@
+// Hyppo hypervisor loadfile test — exercises mega65_h_setname,
+// mega65_h_loadfile, and mega65_h_loadfile_attic wrappers.
+//
+// Requires xemu with -hdosvirt -hdosdir pointing to a directory
+// containing TEST.BIN (8 bytes: DE AD BE EF CA FE BA BE).
+//
+// Exit codes (line numbers via xemu_assert):
+//   0 = all tests passed
+//   non-zero = line number of failed assertion
+
+#include <mega65.h>
+#include <stdint.h>
+
+#include "../mega65-common/xemu-test.h"
+
+static const uint8_t expected[] = {0xDE, 0xAD, 0xBE, 0xEF,
+                                   0xCA, 0xFE, 0xBA, 0xBE};
+
+#define LOAD_ADDR 0x7000
+#define VERIFY_ADDR 0x7100
+
+// Enhanced DMA job for 28-bit copy (attic RAM -> chip RAM)
+static struct {
+  uint8_t opt_f018b;
+  uint8_t opt_src_hi;
+  uint8_t src_hi_val;
+  uint8_t opt_dst_hi;
+  uint8_t dst_hi_val;
+  uint8_t end_option;
+  struct DMAList_F018B list;
+} dma_job;
+
+static void dma_copy_28bit(uint32_t src, uint32_t dst, uint16_t count) {
+  dma_job.opt_f018b = ENABLE_F018B_OPT;
+  dma_job.opt_src_hi = SRC_ADDR_BITS_OPT;
+  dma_job.src_hi_val = (uint8_t)(src >> 20);
+  dma_job.opt_dst_hi = DST_ADDR_BITS_OPT;
+  dma_job.dst_hi_val = (uint8_t)(dst >> 20);
+  dma_job.end_option = 0x00;
+
+  dma_job.list.command = DMA_COPY_CMD;
+  dma_job.list.count = count;
+  dma_job.list.source_addr = (uint16_t)(src & 0xFFFF);
+  dma_job.list.source_bank = (uint8_t)((src >> 16) & 0x0F);
+  dma_job.list.dest_addr = (uint16_t)(dst & 0xFFFF);
+  dma_job.list.dest_bank = (uint8_t)((dst >> 16) & 0x0F);
+  dma_job.list.command_msb = 0;
+  dma_job.list.modulo = 0;
+
+  DMA.enable_f018b = 1;
+  DMA.addr_bank = 0;
+  DMA.addr_msb = ((uint16_t)&dma_job) >> 8;
+  DMA.trigger_enhanced = ((uint16_t)&dma_job) & 0xFF;
+}
+
+int main(void) {
+  // --- Test 1: loadfile to chip RAM ---
+  xemu_assert(mega65_h_setname("TEST.BIN") == 0);
+  xemu_assert(mega65_h_loadfile(LOAD_ADDR) == 0);
+
+  volatile uint8_t *p = (volatile uint8_t *)LOAD_ADDR;
+  for (uint8_t i = 0; i < sizeof(expected); ++i)
+    xemu_assert(p[i] == expected[i]);
+
+  // --- Test 2: loadfile_attic, DMA back to chip RAM ---
+  // Clear verify area to prove DMA actually writes
+  volatile uint8_t *v = (volatile uint8_t *)VERIFY_ADDR;
+  for (uint8_t i = 0; i < sizeof(expected); ++i)
+    v[i] = 0x00;
+
+  xemu_assert(mega65_h_setname("TEST.BIN") == 0);
+  xemu_assert(mega65_h_loadfile_attic(0x0000) == 0);
+
+  dma_copy_28bit(0x08000000UL, (uint32_t)VERIFY_ADDR, sizeof(expected));
+
+  for (uint8_t i = 0; i < sizeof(expected); ++i)
+    xemu_assert(v[i] == expected[i]);
+
+  // --- Error path: loading a name that is not there fails ---
+  xemu_assert(mega65_h_setname("NOFILE.BIN") == 0);
+  xemu_assert(mega65_h_loadfile(LOAD_ADDR) != 0);
+
+  xemu_exit(0);
+}

--- a/test/mega65/kernal-far.c
+++ b/test/mega65/kernal-far.c
@@ -1,0 +1,79 @@
+// MEGA65 KERNAL FAR memory wrapper test — exercises LDA_FAR, STA_FAR,
+// and CMP_FAR by writing data to bank 4 (fast RAM) and reading it back.
+//
+// Test plan:
+//   1. STA_FAR: write 8 bytes to bank 4:$2000
+//   2. LDA_FAR: read each byte back and verify
+//   3. CMP_FAR: compare each byte and verify equality + inequality
+
+#include <mega65.h>
+#include <stdint.h>
+
+#include "../mega65-common/xemu-test.h"
+
+// Test pattern: 8 distinct non-zero bytes
+static const uint8_t pattern[] = {0xDE, 0xAD, 0xBE, 0xEF,
+                                  0xCA, 0xFE, 0xBA, 0xBE};
+
+// Bank 4 = fast RAM at physical $42000; address $2000 within the bank.
+#define FAR_BANK 4
+#define FAR_ADDR 0x2000
+
+static volatile uint8_t arg_in;
+static volatile uint8_t arg_out;
+
+int main(void) {
+  // Unlock VIC-IV registers for KERNAL extensions.
+  VICIV.key = VIC4_KEY_VICIV_A;
+  VICIV.key = VIC4_KEY_VICIV_B;
+  VICIV.ctrla = VIC3_PAL_MASK | VIC3_ROMC_MASK | VIC3_CROM9_MASK;
+
+  // --- Phase 1: STA_FAR — write pattern bytes to bank 4:$2000 ---
+  for (uint8_t i = 0; i < sizeof(pattern); i++) {
+    mega65_k_sta_far(FAR_BANK, FAR_ADDR, i, pattern[i]);
+  }
+
+  // --- Phase 2: LDA_FAR — read back and verify each byte ---
+  for (uint8_t i = 0; i < sizeof(pattern); i++) {
+    uint8_t got = mega65_k_lda_far(FAR_BANK, FAR_ADDR, i);
+    if (got != pattern[i])
+      xemu_exit(10 + i); // exit 10-17: LDA_FAR mismatch at byte i
+  }
+
+  // --- Phase 3: CMP_FAR — compare each byte for equality ---
+  for (uint8_t i = 0; i < sizeof(pattern); i++) {
+    if (mega65_k_cmp_far(FAR_BANK, FAR_ADDR, i, pattern[i]) != 0)
+      xemu_exit(20 + i); // exit 20-27: CMP_FAR mismatch at byte i
+  }
+
+  // Verify CMP_FAR returns non-zero for a wrong value
+  if (mega65_k_cmp_far(FAR_BANK, FAR_ADDR, 0, 0x00) == 0)
+    xemu_exit(30); // exit 30: CMP_FAR false positive
+
+  // --- Phase 4: arguments must survive the call ---
+  // Bank, address and index travel in A/X/Y, all of which these wrappers
+  // overwrite before entering the KERNAL. Volatile keeps the values in
+  // registers across the call instead of being constant-folded away.
+  arg_in = FAR_BANK;
+  {
+    uint8_t bank = arg_in;
+    (void)mega65_k_lda_far(bank, FAR_ADDR, 0);
+    arg_out = bank;
+  }
+  if (arg_out != FAR_BANK)
+    xemu_exit(40); // exit 40: LDA_FAR ate its bank argument
+
+  arg_in = FAR_BANK;
+  {
+    uint8_t bank = arg_in;
+    mega65_k_sta_far(bank, FAR_ADDR, 0, pattern[0]);
+    arg_out = bank;
+  }
+  if (arg_out != FAR_BANK)
+    xemu_exit(41); // exit 41: STA_FAR ate its bank argument
+
+  // Restore startup ROM banking.
+  VICIV.ctrla = VIC3_PAL_MASK | VIC3_CROM9_MASK;
+
+  xemu_exit(0);
+}

--- a/test/mega65/kernal.c
+++ b/test/mega65/kernal.c
@@ -1,0 +1,199 @@
+// MEGA65 KERNAL wrapper test — exercises the C-callable KERNAL wrappers
+// added in the mega65-kernal-setbnk branch.
+//
+// Tests run under xemu in headless mode. Each test uses a unique exit code
+// so failures pinpoint the exact broken wrapper. All tests use KERNAL
+// functions that work without disk hardware (no FDC/D81 dependency).
+//
+// Note: disk I/O tests are not included because xemu's FDC SWAP
+// emulation detaches D81 images during C65 boot, before user code runs.
+
+#include <cbm.h>
+#include <mega65.h>
+#include <stdint.h>
+
+#include "../mega65-common/xemu-test.h"
+
+enum {
+  EXIT_OK = 0,
+
+  EXIT_SCRORG_MAX_COL = 1,
+  EXIT_SCRORG_MAX_ROW = 2,
+
+  EXIT_PLOT_LINE = 3,
+  EXIT_PLOT_COL = 4,
+
+  EXIT_GETIO_IN = 5,
+  EXIT_GETIO_OUT = 6,
+
+  EXIT_RDTIM_HOURS = 7,
+  EXIT_RDTIM_MINUTES = 8,
+  EXIT_RDTIM_SECONDS = 9,
+
+  EXIT_GETLFS_LA = 10,
+  EXIT_GETLFS_FA = 11,
+  EXIT_GETLFS_SA = 12,
+
+  EXIT_LKUPLA_GHOST = 13,
+  EXIT_READST = 14,
+
+  EXIT_ARG_SETBNK = 15,
+  EXIT_ARG_SETBNK_28 = 16,
+  EXIT_ARG_SETTIM = 17,
+  EXIT_ARG_PLOT_SET = 18,
+
+  EXIT_ADDKEY_FULL = 19,
+  EXIT_ADDKEY_READBACK = 20,
+  EXIT_SWAPPER_WIDTH = 21,
+  EXIT_SWAPPER_RESTORE = 22,
+  EXIT_SYSFLAGS_ROUNDTRIP = 23,
+  EXIT_SYSFLAGS_RESTORE = 24,
+};
+
+// Arguments travel in A/X/Y, and the KERNAL routines behind these wrappers do
+// not hand those registers back. Reading an argument after the call is what
+// catches a wrapper that declares one input-only; volatile keeps the value in
+// a register across the call instead of being constant-folded away.
+static volatile uint8_t arg_in;
+static volatile uint8_t arg_out;
+
+int main(void) {
+  // Unlock VIC-IV registers and map the C65 ROM at $C000, which the MEGA65
+  // KERNAL extensions live behind.
+  VICIV.key = VIC4_KEY_VICIV_A;
+  VICIV.key = VIC4_KEY_VICIV_B;
+  VICIV.ctrla = VIC3_PAL_MASK | VIC3_ROMC_MASK | VIC3_CROM9_MASK;
+
+  // --- Test SCRORG: screen dimensions should be valid ---
+  mega65_screen_info_t scr = mega65_k_scrorg();
+  // C65 boots in 80-column mode (max_col=79) or 40-column (max_col=39)
+  if (scr.max_col != 79 && scr.max_col != 39)
+    xemu_exit(EXIT_SCRORG_MAX_COL);
+  if (scr.max_row != 24) // 25 rows
+    xemu_exit(EXIT_SCRORG_MAX_ROW);
+
+  // --- Test PLOT: set cursor position, read it back ---
+  mega65_k_plot_set(10, 20);
+  mega65_plot_t plot = mega65_k_plot_get();
+  if (plot.line != 10)
+    xemu_exit(EXIT_PLOT_LINE);
+  if (plot.col != 20)
+    xemu_exit(EXIT_PLOT_COL);
+
+  // --- Test GETIO: default I/O devices after boot ---
+  mega65_io_t io = mega65_k_getio();
+  if (io.input_dev != 0) // 0 = keyboard
+    xemu_exit(EXIT_GETIO_IN);
+  if (io.output_dev != 3) // 3 = screen
+    xemu_exit(EXIT_GETIO_OUT);
+
+  // --- Test SETTIM/RDTIM: set TOD clock and read back ---
+  // BCD values: 0x12 = 12, 0x30 = 30, 0x45 = 45
+  mega65_k_settim(0x12, 0x30, 0x45, 0x00);
+  mega65_tod_t tod = mega65_k_rdtim();
+  if (tod.hours != 0x12)
+    xemu_exit(EXIT_RDTIM_HOURS);
+  if (tod.minutes != 0x30)
+    xemu_exit(EXIT_RDTIM_MINUTES);
+  // Seconds may have ticked; accept 0x45 or 0x46
+  if (tod.seconds != 0x45 && tod.seconds != 0x46)
+    xemu_exit(EXIT_RDTIM_SECONDS);
+
+  // --- Test SETLFS/GETLFS: set file params and read back ---
+  cbm_k_setlfs(5, 8, 2);
+  mega65_lfs_t lfs = mega65_k_getlfs();
+  if (lfs.la != 5)
+    xemu_exit(EXIT_GETLFS_LA);
+  if (lfs.fa != 8)
+    xemu_exit(EXIT_GETLFS_FA);
+  if (lfs.sa != 2)
+    xemu_exit(EXIT_GETLFS_SA);
+
+  // --- Test LKUPLA: search for non-existent logical file ---
+  uint8_t lk_fa, lk_sa;
+  if (mega65_k_lkupla(99, &lk_fa, &lk_sa) == 0)
+    xemu_exit(EXIT_LKUPLA_GHOST); // should NOT be found
+
+  // --- Test READST: status should be 0 after fresh boot ---
+  if (cbm_k_readst() != 0)
+    xemu_exit(EXIT_READST);
+
+  // --- Arguments must survive the call (see note above) ---
+  arg_in = 3;
+  {
+    uint8_t mem_bank = arg_in;
+    mega65_k_setbnk(mem_bank, 0); // ends in "txa", so A is gone
+    arg_out = mem_bank;
+  }
+  if (arg_out != 3)
+    xemu_exit(EXIT_ARG_SETBNK);
+
+  arg_in = 4;
+  {
+    uint8_t mem_mb = arg_in;
+    mega65_k_setbnk_28(mem_mb, 0, 0, 0);
+    arg_out = mem_mb;
+  }
+  if (arg_out != 4)
+    xemu_exit(EXIT_ARG_SETBNK_28);
+
+  arg_in = 0x21; // BCD hours >= 0x13 take the PM path, which rewrites Y
+  {
+    uint8_t bcd_hours = arg_in;
+    mega65_k_settim(bcd_hours, 0x00, 0x00, 0x00);
+    arg_out = bcd_hours;
+  }
+  if (arg_out != 0x21)
+    xemu_exit(EXIT_ARG_SETTIM);
+
+  arg_in = 5;
+  {
+    uint8_t plot_line = arg_in;
+    mega65_k_plot_set(plot_line, 0); // recomputes X on the way out
+    arg_out = plot_line;
+  }
+  if (arg_out != 5)
+    xemu_exit(EXIT_ARG_PLOT_SET);
+
+  // --- ADDKEY: a character pushed into the buffer comes back from GETIN ---
+  if (mega65_k_addkey('A'))
+    xemu_exit(EXIT_ADDKEY_FULL); // buffer was full
+  if (cbm_k_getin() != 'A')
+    xemu_exit(EXIT_ADDKEY_READBACK);
+
+  // --- SETMSG: accepts a mode without disturbing the channels ---
+  mega65_k_setmsg(0); // messages off; nothing observable to assert
+
+  // --- SWAPPER: toggles 40/80 columns, which SCRORG reports ---
+  {
+    uint8_t was = mega65_k_scrorg().max_col;
+    mega65_k_swapper();
+    uint8_t now = mega65_k_scrorg().max_col;
+    if (now == was || (now != 39 && now != 79))
+      xemu_exit(EXIT_SWAPPER_WIDTH);
+    mega65_k_swapper(); // back to the mode the test started in
+    if (mega65_k_scrorg().max_col != was)
+      xemu_exit(EXIT_SWAPPER_RESTORE);
+  }
+
+  // --- SYSFLAGS: the lock bits read back as written ---
+  {
+    uint8_t was = mega65_k_sysflags_get();
+    mega65_k_sysflags_set(MEGA65_LOCK_GO64 | MEGA65_LOCK_NO_SCROLL);
+    // Put a known, different value in A in between: set() leaves its argument
+    // there, so a get() that took the wrong carry path would hand that back
+    // and look correct.
+    if (cbm_k_readst() != 0)
+      xemu_exit(EXIT_READST);
+    if (mega65_k_sysflags_get() != (MEGA65_LOCK_GO64 | MEGA65_LOCK_NO_SCROLL))
+      xemu_exit(EXIT_SYSFLAGS_ROUNDTRIP);
+    mega65_k_sysflags_set(was); // leave the keyboard as the test found it
+    if (mega65_k_sysflags_get() != was)
+      xemu_exit(EXIT_SYSFLAGS_RESTORE);
+  }
+
+  // Restore startup ROM banking (C65 ROMs unmapped for max RAM).
+  VICIV.ctrla = VIC3_PAL_MASK | VIC3_CROM9_MASK;
+
+  xemu_exit(EXIT_OK);
+}


### PR DESCRIPTION
Adds SD card MMIO for working with the Mega65 SD card. Follows same style and format as other hardware registers.

Sits on top of #448 and should be merged after that.